### PR TITLE
Partition columns now have correct type

### DIFF
--- a/awswrangler/__version__.py
+++ b/awswrangler/__version__.py
@@ -1,4 +1,4 @@
 __title__ = "awswrangler"
 __description__ = "Utility belt to handle data on AWS."
-__version__ = "0.0.1"
+__version__ = "0.0.2"
 __license__ = "Apache License 2.0"

--- a/awswrangler/exceptions.py
+++ b/awswrangler/exceptions.py
@@ -64,3 +64,7 @@ class QueryCancelled(Exception):
 
 class QueryFailed(Exception):
     pass
+
+
+class PartitionColumnTypeNotFound(Exception):
+    pass


### PR DESCRIPTION
Previously all partition columns where of the string type. The same
logic for non partition columns is reused to find out the type of the
partition column.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
