### PR TITLE
Add compression for Pandas.to_parquet

### DIFF
--- a/awswrangler/exceptions.py
+++ b/awswrangler/exceptions.py
@@ -72,3 +72,7 @@ class InvalidSerDe(Exception):
 
 class ApiError(Exception):
     pass
+
+
+class InvalidCompression(Exception):
+    pass


### PR DESCRIPTION
Issue #26 

Add compression for Pandas.to_parquet and prepare the structures to do the same with Pandas.to_csv.
But for now the second is blocked by a [Pandas limitation](https://github.com/pandas-dev/pandas/issues/22555).


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
