### PR TITLE
Add Spark.create_glue_table() and Athena.repair_table()

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,11 +22,12 @@
 * Pandas -> Redshift (Parallel)
 * CSV (S3) -> Pandas (One shot or Batching)
 * Athena -> Pandas (One shot or Batching)
-* CloudWatch Logs Insights -> Pandas (NEW :star:)
-* Encrypt Pandas Dataframes on S3 with KMS keys (NEW :star:)
+* CloudWatch Logs Insights -> Pandas
+* Encrypt Pandas Dataframes on S3 with KMS keys
 
 ### PySpark
-* PySpark -> Redshift (Parallel) (NEW :star:)
+* PySpark -> Redshift (Parallel)
+* Register Glue table from Dataframe stored on S3 (NEW :star:)
 
 ### General
 * List S3 objects (Parallel)
@@ -35,7 +36,8 @@
 * Delete NOT listed S3 objects (Parallel)
 * Copy listed S3 objects (Parallel)
 * Get the size of S3 objects (Parallel)
-* Get CloudWatch Logs Insights query results (NEW :star:)
+* Get CloudWatch Logs Insights query results
+* Load partitions on Athena/Glue table (repair table) (NEW :star:)
 
 ## Installation
 
@@ -166,6 +168,23 @@ session.spark.to_redshift(
 )
 ```
 
+#### Register Glue table from Dataframe stored on S3
+
+```py3
+dataframe.write \
+        .mode("overwrite") \
+        .format("parquet") \
+        .partitionBy(["year", "month"]) \
+        .save(compression="gzip", path="s3://...")
+session = awswrangler.Session(spark_session=spark)
+session.spark.create_glue_table(dataframe=dataframe,
+                                file_format="parquet",
+                                partition_by=["year", "month"],
+                                path="s3://...",
+                                compression="gzip",
+                                database="my_database")
+```
+
 ### General
 
 #### Deleting a bunch of S3 objects (parallel :rocket:)
@@ -183,6 +202,13 @@ results = session.cloudwatchlogs.query(
     log_group_names=[LOG_GROUP_NAME],
     query="fields @timestamp, @message | sort @timestamp desc | limit 5",
 )
+```
+
+#### Load partitions on Athena/Glue table (repair table)
+
+```py3
+session = awswrangler.Session()
+session.athena.repair_table(database="db_name", table="tbl_name")
 ```
 
 ## Diving Deep
@@ -217,13 +243,13 @@ results = session.cloudwatchlogs.query(
 
 * Fork the AWS Data Wrangler repository and clone that into your development environment
 
-* Go to the project's directory create a Python's virtual environment for the project (**python -m venv venv && source source venv/bin/activate**)
+* Go to the project's directory create a Python's virtual environment for the project (**python -m venv venv && source venv/bin/activate**)
 
 * Run **./install-dev.sh**
 
 * Go to the *testing* directory
 
-* Configure the parameters.json file with your AWS environment infos (Make sure that your Redshift will not be open for the World!)
+* Configure the parameters.json file with your AWS environment infos (Make sure that your Redshift will not be open for the World! Configure your security group to only give access for your IP.)
 
 * Deploy the Cloudformation stack **./deploy-cloudformation.sh**
 

--- a/awswrangler/athena.py
+++ b/awswrangler/athena.py
@@ -118,3 +118,25 @@ class Athena:
             raise QueryCancelled(
                 response["QueryExecution"]["Status"].get("StateChangeReason"))
         return response
+
+    def repair_table(self, database, table, s3_output=None):
+        """
+        Hive's metastore consistency check
+        "MSCK REPAIR TABLE table;"
+        Recovers partitions and data associated with partitions.
+        Use this statement when you add partitions to the catalog.
+        It is possible it will take some time to add all partitions.
+        If this operation times out, it will be in an incomplete state
+        where only a few partitions are added to the catalog.
+
+        :param database: Glue database name
+        :param table: Glue table name
+        :param s3_output: AWS S3 path
+        :return: Query execution ID
+        """
+        query = f"MSCK REPAIR TABLE {table};"
+        query_id = self.run_query(query=query,
+                                  database=database,
+                                  s3_output=s3_output)
+        self.wait_query(query_execution_id=query_id)
+        return query_id

--- a/awswrangler/glue.py
+++ b/awswrangler/glue.py
@@ -141,7 +141,7 @@ class Glue:
             partition_cols=partition_cols,
             preserve_index=preserve_index,
             cast_columns=cast_columns)
-        table = table if table else Glue._parse_table_name(path)
+        table = table if table else Glue.parse_table_name(path)
         table = table.lower().replace(".", "_")
         if mode == "overwrite":
             self.delete_table_if_exists(database=database, table=table)
@@ -301,7 +301,7 @@ class Glue:
         return schema_built, partition_cols_schema_built
 
     @staticmethod
-    def _parse_table_name(path):
+    def parse_table_name(path):
         if path[-1] == "/":
             path = path[:-1]
         return path.rpartition("/")[2]

--- a/awswrangler/pandas.py
+++ b/awswrangler/pandas.py
@@ -576,12 +576,15 @@ class Pandas:
         """
         if compression is not None:
             compression = compression.lower()
+        file_format = file_format.lower()
+        if file_format not in ["parquet", "csv"]:
+            raise UnsupportedFileFormat(file_format)
         if file_format == "csv":
             if compression not in Pandas.VALID_CSV_COMPRESSIONS:
                 raise InvalidCompression(
                     f"{compression} isn't a valid CSV compression. Try: {Pandas.VALID_CSV_COMPRESSIONS}"
                 )
-        if file_format == "parquet":
+        elif file_format == "parquet":
             if compression not in Pandas.VALID_PARQUET_COMPRESSIONS:
                 raise InvalidCompression(
                     f"{compression} isn't a valid PARQUET compression. Try: {Pandas.VALID_PARQUET_COMPRESSIONS}"
@@ -641,9 +644,6 @@ class Pandas:
         logger.debug(f"procs_io_bound: {procs_io_bound}")
         if path[-1] == "/":
             path = path[:-1]
-        file_format = file_format.lower()
-        if file_format not in ["parquet", "csv"]:
-            raise UnsupportedFileFormat(file_format)
         objects_paths = []
         if procs_cpu_bound > 1:
             bounders = _get_bounders(dataframe=dataframe,

--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -24,13 +24,13 @@ Step-by-step
 
 * Fork the AWS Data Wrangler repository and clone that into your development environment
 
-* Go to the project's directory create a Python's virtual environment for the project (**python -m venv venv && source source venv/bin/activate**)
+* Go to the project's directory create a Python's virtual environment for the project (**python -m venv venv && source venv/bin/activate**)
 
 * Run **./install-dev.sh**
 
 * Go to the *testing* directory
 
-* Configure the parameters.json file with your AWS environment infos (Make sure that your Redshift will not be open for the World!)
+* Configure the parameters.json file with your AWS environment infos (Make sure that your Redshift will not be open for the World! Configure your security group to only give access for your IP.)
 
 * Deploy the Cloudformation stack **./deploy-cloudformation.sh**
 

--- a/docs/source/examples.rst
+++ b/docs/source/examples.rst
@@ -139,6 +139,24 @@ Loading Pyspark Dataframe to Redshift
         mode="append",
     )
 
+Register Glue table from Dataframe stored on S3
+```````````````````````````````````````````````
+
+.. code-block:: python
+
+    dataframe.write \
+            .mode("overwrite") \
+            .format("parquet") \
+            .partitionBy(["year", "month"]) \
+            .save(compression="gzip", path="s3://...")
+    session = awswrangler.Session(spark_session=spark)
+    session.spark.create_glue_table(dataframe=dataframe,
+                                    file_format="parquet",
+                                    partition_by=["year", "month"],
+                                    path="s3://...",
+                                    compression="gzip",
+                                    database="my_database")
+
 General
 -------
 
@@ -160,3 +178,11 @@ Get CloudWatch Logs Insights query results
         log_group_names=[LOG_GROUP_NAME],
         query="fields @timestamp, @message | sort @timestamp desc | limit 5",
     )
+
+Load partitions on Athena/Glue table (repair table)
+```````````````````````````````````````````````````
+
+.. code-block:: python
+
+    session = awswrangler.Session()
+    session.athena.repair_table(database="db_name", table="tbl_name")

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -20,12 +20,13 @@ Pandas
 * Pandas -> Redshift (Parallel)
 * CSV (S3) -> Pandas (One shot or Batching)
 * Athena -> Pandas (One shot or Batching)
-* CloudWatch Logs Insights -> Pandas (NEW)
-* Encrypt Pandas Dataframes on S3 with KMS keys (NEW)
+* CloudWatch Logs Insights -> Pandas
+* Encrypt Pandas Dataframes on S3 with KMS keys
 
 PySpark
 ```````
-* PySpark -> Redshift (Parallel) (NEW)
+* PySpark -> Redshift (Parallel)
+* Register Glue table from Dataframe stored on S3 (NEW)
 
 General
 ```````
@@ -35,7 +36,8 @@ General
 * Delete NOT listed S3 objects (Parallel)
 * Copy listed S3 objects (Parallel)
 * Get the size of S3 objects (Parallel)
-* Get CloudWatch Logs Insights query results (NEW)
+* Get CloudWatch Logs Insights query results
+* Load partitions on Athena/Glue table (repair table) (NEW)
 
 
 Table Of Contents

--- a/testing/template.yaml
+++ b/testing/template.yaml
@@ -131,6 +131,7 @@ Resources:
     Properties:
       CatalogId: !Ref AWS::AccountId
       DatabaseInput:
+        Name: awswrangler_test
         Description: AWS Data Wrangler Test Arena - Glue Database
 
   LogGroup:

--- a/testing/test_awswrangler/test_spark.py
+++ b/testing/test_awswrangler/test_spark.py
@@ -3,6 +3,7 @@ import logging
 import pytest
 import boto3
 from pyspark.sql import SparkSession
+from pyspark.sql.functions import lit, array, create_map, struct
 
 from awswrangler import Session
 
@@ -39,6 +40,16 @@ def bucket(session, cloudformation_outputs):
     session.s3.delete_objects(path=f"s3://{bucket}/")
 
 
+@pytest.fixture(scope="module")
+def database(cloudformation_outputs):
+    if "GlueDatabaseName" in cloudformation_outputs:
+        database = cloudformation_outputs["GlueDatabaseName"]
+    else:
+        raise Exception(
+            "You must deploy the test infrastructure using Cloudformation!")
+    yield database
+
+
 @pytest.mark.parametrize(
     "sample_name",
     ["nano", "micro", "small"],
@@ -52,7 +63,7 @@ def test_read_csv(session, bucket, sample_name):
         schema = "id BIGINT, name STRING, date DATE"
         timestamp_format = "dd-MM-yy"
     elif sample_name == "nano":
-        schema = "id INTEGER, name STRING, value DOUBLE, date TIMESTAMP, time TIMESTAMP"
+        schema = "id INTEGER, name STRING, value DOUBLE, date DATE, time TIMESTAMP"
         timestamp_format = "yyyy-MM-dd"
     dataframe = session.spark.read_csv(path=path,
                                        schema=schema,
@@ -69,3 +80,87 @@ def test_read_csv(session, bucket, sample_name):
                                         header=True)
     assert dataframe.count() == dataframe2.count()
     assert len(list(dataframe.columns)) == len(list(dataframe2.columns))
+
+
+@pytest.mark.parametrize(
+    "compression, partition_by",
+    [("snappy", []), ("gzip", ["date", "value"]), ("none", ["time"])],
+)
+def test_create_glue_table_parquet(session, bucket, database, compression,
+                                   partition_by):
+    path = "data_samples/nano.csv"
+    schema = "id INTEGER, name STRING, value DOUBLE, date DATE, time TIMESTAMP"
+    timestamp_format = "yyyy-MM-dd"
+    dataframe = session.spark.read_csv(path=path,
+                                       schema=schema,
+                                       timestampFormat=timestamp_format,
+                                       dateFormat=timestamp_format,
+                                       header=True)
+    dataframe = dataframe \
+        .withColumn("my_array", array(lit(0), lit(1))) \
+        .withColumn("my_struct", struct(lit("text").alias("a"), lit(1).alias("b"))) \
+        .withColumn("my_map", create_map(lit("k0"), lit(1.0), lit("k1"), lit(2.0)))
+    s3_path = f"s3://{bucket}/test"
+    dataframe.write \
+        .mode("overwrite") \
+        .format("parquet") \
+        .partitionBy(partition_by) \
+        .save(compression=compression, path=s3_path)
+    session.spark.create_glue_table(dataframe=dataframe,
+                                    file_format="parquet",
+                                    partition_by=partition_by,
+                                    path=s3_path,
+                                    compression=compression,
+                                    database=database,
+                                    table="test",
+                                    replace_if_exists=True)
+    query = "select count(*) as counter from test"
+    pandas_df = session.pandas.read_sql_athena(sql=query, database=database)
+    assert pandas_df.iloc[0]["counter"] == 5
+    query = "select my_array[1] as foo, my_struct.a as boo, my_map['k0'] as bar from test limit 1"
+    pandas_df = session.pandas.read_sql_athena(sql=query, database=database)
+    assert pandas_df.iloc[0]["foo"] == 0
+    assert pandas_df.iloc[0]["boo"] == "text"
+    assert pandas_df.iloc[0]["bar"] == 1.0
+
+
+@pytest.mark.parametrize(
+    "compression, partition_by, serde",
+    [("gzip", [], None), ("gzip", ["date", "value"], None),
+     ("none", ["time"], "OpenCSVSerDe"), ("gzip", [], "LazySimpleSerDe"),
+     ("gzip", ["date", "value"], "LazySimpleSerDe"),
+     ("none", ["time"], "LazySimpleSerDe")],
+)
+def test_create_glue_table_csv(session, bucket, database, compression,
+                               partition_by, serde):
+    path = "data_samples/nano.csv"
+    schema = "id INTEGER, name STRING, value DOUBLE, date DATE, time TIMESTAMP"
+    timestamp_format = "yyyy-MM-dd"
+    dataframe = session.spark.read_csv(path=path,
+                                       schema=schema,
+                                       timestampFormat=timestamp_format,
+                                       dateFormat=timestamp_format,
+                                       header=True)
+    s3_path = f"s3://{bucket}/test"
+    dataframe.write \
+        .mode("overwrite") \
+        .format("csv") \
+        .partitionBy(partition_by) \
+        .save(compression=compression, path=s3_path)
+    session.spark.create_glue_table(dataframe=dataframe,
+                                    file_format="csv",
+                                    partition_by=partition_by,
+                                    path=s3_path,
+                                    compression=compression,
+                                    database=database,
+                                    table="test",
+                                    serde=serde,
+                                    replace_if_exists=True)
+    query = "select count(*) as counter from test"
+    pandas_df = session.pandas.read_sql_athena(sql=query, database=database)
+    assert pandas_df.iloc[0]["counter"] == 5
+    query = "select id, name, value from test where cast(id as varchar) = '4' limit 1"
+    pandas_df = session.pandas.read_sql_athena(sql=query, database=database)
+    assert int(pandas_df.iloc[0]["id"]) == 4
+    assert pandas_df.iloc[0]["name"] == "four"
+    assert float(pandas_df.iloc[0]["value"]) == 4.0


### PR DESCRIPTION
Issue #29 

#### Register Glue table from Dataframe stored on S3

```py3
dataframe.write \
        .mode("overwrite") \
        .format("parquet") \
        .partitionBy(["year", "month"]) \
        .save(compression="gzip", path="s3://...")
session = awswrangler.Session(spark_session=spark)
session.spark.create_glue_table(dataframe=dataframe,
                                file_format="parquet",
                                partition_by=["year", "month"],
                                path="s3://...",
                                compression="gzip",
                                database="my_database")
```

#### Load partitions on Athena/Glue table (repair table)

```py3
session = awswrangler.Session()
session.athena.repair_table(database="db_name", table="tbl_name")
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
