### PR TITLE
Make explicit that there is not support for Glue PySpark by now

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,9 +52,10 @@
 
 Runs only with Python 3.6 and beyond.
 
-Runs anywhere (AWS Lambda, AWS Glue, EMR, EC2, on-premises, local, etc).
+Runs anywhere (AWS Lambda, AWS Glue Python Shell, EMR, EC2, on-premises, local, etc).
 
 *P.S.* Lambda Layer's bundle and Glue's wheel/egg are available to [download](https://github.com/awslabs/aws-data-wrangler/releases). It's just upload and run! :rocket:
+*P.P.S.* AWS Data Wrangler counts on compiled dependencies (C/C++) so there is no support for Glue PySpark by now.
 
 ## Examples
 

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -7,6 +7,7 @@ Installation
 
 Runs only with Python 3.6 and beyond.
 
-Runs anywhere (AWS Lambda, AWS Glue, EMR, EC2, on-premises, local, etc).
+Runs anywhere (AWS Lambda, AWS Glue Python Shell, EMR, EC2, on-premises, local, etc).
 
 **P.S.** Lambda Layer's bundle and Glue's wheel/egg are available to `download <https://github.com/awslabs/aws-data-wrangler/releases>`_. It's just upload and run! 🚀
+*P.P.S.* AWS Data Wrangler counts with compiled dependencies (C/C++) so there is no support for Glue PySpark by now.


### PR DESCRIPTION
Issue #46 

Make explicit that there is not support for Glue PySpark by now


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
