### PR TITLE
Log the names of duplicated columns and not boolean array

### DIFF
--- a/awswrangler/pandas.py
+++ b/awswrangler/pandas.py
@@ -1000,5 +1000,5 @@ class Pandas:
         if inplace is False:
             dataframe = dataframe.copy(deep=True)
         duplicated_cols = dataframe.columns.duplicated()
-        logger.warning(f"Dropping repeated columns: {duplicated_cols}")
+        logger.warning(f"Dropping repeated columns: {list(dataframe.columns[duplicated_cols])}")
         return dataframe.loc[:, ~duplicated_cols]


### PR DESCRIPTION
*Description of changes:*
The logs for this are currently producing a boolean array, like:
```
W1024 16:20:42.335944 140524353476352 pandas.py:1003] Dropping repeated columns: [False False False False False False False False False False False False
 False False False False False False False False False False False False
 False False False False False False False False False False False False
 False False False False False False False False False False False False
 False False False False False False False False False False False False
 False False False False False False False False False False False False
 False]
```
This makes it so that it prints the names of the columns instead:
```
Dropping repeated columns: ['duplicated_col_name']
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
