### PR TITLE
disable remove repeated underscores rule from _normalize_name as athena allows it

### DIFF
--- a/awswrangler/athena.py
+++ b/awswrangler/athena.py
@@ -269,7 +269,6 @@ class Athena:
         name = re.sub("(.)([A-Z][a-z]+)", r"\1_\2", name)
         name = re.sub("([a-z0-9])([A-Z])", r"\1_\2", name)
         name = name.lower()
-        name = re.sub(r"(_)\1+", "\\1", name)  # remove repeated underscores
         name = name[1:] if name.startswith("_") else name  # remove trailing underscores
         name = name[:-1] if name.endswith("_") else name  # remove trailing underscores
         return name


### PR DESCRIPTION


When we are trying to use pandas.to_redshift function, a columnName has double underscore, like `__dc_timelabel`
This internally call to_s3, which is trying to `normalize_columns_names_athena`. This ended up with columnName `dc_timelabel` in redshift and it's unexpected behavior.

The issue is athena actually support repeated underscores, we should not remove it.


disable the rule of remove repeated underscores in function `normalize_columns_names_athena` in athena.py


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
