### PR TITLE
disable normalize name to remove underscore as underscore is allowed in athena columnName

### DIFF
--- a/awswrangler/athena.py
+++ b/awswrangler/athena.py
@@ -269,8 +269,6 @@ class Athena:
         name = re.sub("(.)([A-Z][a-z]+)", r"\1_\2", name)
         name = re.sub("([a-z0-9])([A-Z])", r"\1_\2", name)
         name = name.lower()
-        name = name[1:] if name.startswith("_") else name  # remove trailing underscores
-        name = name[:-1] if name.endswith("_") else name  # remove trailing underscores
         return name
 
     @staticmethod


### PR DESCRIPTION
Not able to create table with leading/trailing underscore in columnName, but this is allowed in athena

remove _normalize_name underscore strip

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
