### PR TITLE
fixing read_csv missing session token and broken s3 path

### DIFF
--- a/awswrangler/athena.py
+++ b/awswrangler/athena.py
@@ -470,7 +470,7 @@ def read_sql_query(  # pylint: disable=too-many-branches,too-many-locals
     dtype, parse_timestamps, parse_dates, converters, binaries = _get_query_metadata(
         query_execution_id=query_id, categories=categories, boto3_session=session
     )
-    path = f"{_s3_output}{query_id}.csv"
+    path = f"{_s3_output}/{query_id}.csv"
     s3.wait_objects_exist(paths=[path], use_threads=False, boto3_session=session)
     _logger.debug(f"Start CSV reading from {path}")
     ret = s3.read_csv(
@@ -484,6 +484,7 @@ def read_sql_query(  # pylint: disable=too-many-branches,too-many-locals
         chunksize=chunksize,
         skip_blank_lines=False,
         use_threads=False,
+        boto3_session=session,
     )
     _logger.debug("Start type casting...")
     if chunksize is None:


### PR DESCRIPTION
Fixes two small bugs in `athena.read_sql_query`:
* Missing `/` in the path fstring between the s3 output and query id.
    * Surfaces itself as a `WaiterError: Waiter ObjectExists failed: Max attempts exceeded` during runtime.
* Missing `boto3_session=session` in `s3.read_csv`.
    * Surfaces itself as a `ClientError: An error occurred (403) when calling the HeadObject operation: Forbidden`

I noticed that my Athena queries were being run and stored as CSVs in S3 as expected but erroring before loading into a dataframe. After trying out these two fixes it's smooth sailing for me!

Really excited about this tool and keep up the great work!