### PR TITLE
Adding a note about collisions for sanitize_dataframe_columns_names.

### DIFF
--- a/awswrangler/catalog.py
+++ b/awswrangler/catalog.py
@@ -679,8 +679,10 @@ def sanitize_dataframe_columns_names(df: pd.DataFrame) -> pd.DataFrame:
     - Remove non alphanumeric characters
     - Convert CamelCase to snake_case
 
-    Note: after transformation, some column names might not be unique anymore.
-        Example: the columns ["A", "a"] will be sanitized to ["a", "a"]
+    Note
+    ----
+    After transformation, some column names might not be unique anymore.
+    Example: the columns ["A", "a"] will be sanitized to ["a", "a"]
 
     Parameters
     ----------

--- a/awswrangler/catalog.py
+++ b/awswrangler/catalog.py
@@ -679,6 +679,9 @@ def sanitize_dataframe_columns_names(df: pd.DataFrame) -> pd.DataFrame:
     - Remove non alphanumeric characters
     - Convert CamelCase to snake_case
 
+    Note: after transformation, some column names might not be unique anymore.
+        Example: the columns ["A", "a"] will be sanitized to ["a", "a"]
+
     Parameters
     ----------
     df : pandas.DataFrame


### PR DESCRIPTION
This is a modest change to the documentation. It adds a note to the the `sanitize_dataframe_columns_names`, explaining that it doesn't guard the user from collisions. 

Feel free to ignore if it's assumed that the user should know about this.

Example:

```python
import awswrangler as wr

d = {'Col1': [1, 2], 'col1': [3, 4]}
df = pd.DataFrame(data=d)
df_normalized = wr.catalog.sanitize_dataframe_columns_names(df)

In [13]: df_normalized
Out[13]:
   col1  col1
0     1     3
1     2     4

In [16]: df_normalized["col1"]
Out[16]:
   col1  col1
0     1     3
1     2     4
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
