### PR TITLE
Registering module's type annotations

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,5 @@
 include README.md LICENSE requirements.txt
+include awswrangler/py.typed
 exclude .*
 exclude *.egg-info
 exclude data_samples*

--- a/awswrangler/py.typed
+++ b/awswrangler/py.typed
@@ -1,1 +1,1 @@
-# Marker file for PEP 561. The okraqa package uses inline types.
+# Marker file for PEP 561.

--- a/awswrangler/py.typed
+++ b/awswrangler/py.typed
@@ -1,0 +1,1 @@
+# Marker file for PEP 561. The okraqa package uses inline types.

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ setup(
     long_description_content_type="text/markdown",
     license=about["__license__"],
     packages=find_packages(include=["awswrangler", "awswrangler.*"], exclude=["tests"]),
+    include_package_data=True,
     python_requires=">=3.6, <3.9",
     install_requires=[open("requirements.txt").read().strip().split("\n")],
 )


### PR DESCRIPTION
While most of the module is annotated, the annotations are not registered and therefore can't be used outside of the module, when awswrangler is used as a library.

*Description of changes:*

This PR adds a `py.typed` file to register these annotations. See PEP 561 for more details https://www.python.org/dev/peps/pep-0561/


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
