### PR TITLE
Bumping version to 1.0.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ We just released a new major version `1.0` with breaking changes. Please make su
 
 ![AWS Data Wrangler](docs/source/_static/logo2.png?raw=true "AWS Data Wrangler")
 
-[![Release](https://img.shields.io/badge/release-1.0.3-brightgreen.svg)](https://pypi.org/project/awswrangler/)
+[![Release](https://img.shields.io/badge/release-1.0.4-brightgreen.svg)](https://pypi.org/project/awswrangler/)
 [![Python Version](https://img.shields.io/badge/python-3.6%20%7C%203.7%20%7C%203.8-brightgreen.svg)](https://anaconda.org/conda-forge/awswrangler)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)

--- a/awswrangler/__metadata__.py
+++ b/awswrangler/__metadata__.py
@@ -7,5 +7,5 @@ Documentation: https://aws-data-wrangler.readthedocs.io/
 
 __title__ = "awswrangler"
 __description__ = "Pandas on AWS."
-__version__ = "1.0.3"
+__version__ = "1.0.4"
 __license__ = "Apache License 2.0"

--- a/testing/test_awswrangler/test_metadata.py
+++ b/testing/test_awswrangler/test_metadata.py
@@ -2,7 +2,7 @@ import awswrangler as wr
 
 
 def test_metadata():
-    assert wr.__version__ == "1.0.3"
+    assert wr.__version__ == "1.0.4"
     assert wr.__title__ == "awswrangler"
     assert wr.__description__ == "Pandas on AWS."
     assert wr.__license__ == "Apache License 2.0"


### PR DESCRIPTION
Bumping version to 1.0.4


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
