### PR TITLE
change _create_table (catalog.py) default behavior to do not remove table if exists

### DIFF
--- a/awswrangler/catalog.py
+++ b/awswrangler/catalog.py
@@ -120,7 +120,7 @@ def create_parquet_table(
     columns_comments: Dict[str, str], optional
         Columns names and the related comments (e.g. {'col0': 'Column 0.', 'col1': 'Column 1.', 'col2': 'Partition.'}).
     mode: str
-        'overwrite' to recreate any possible axisting table or 'append' to keep any possible axisting table.
+        'overwrite' to recreate any possible existing table or 'append' to keep any possible existing table.
     boto3_session : boto3.Session(), optional
         Boto3 Session. The default boto3 session will be used if boto3_session receive None.
 
@@ -967,11 +967,11 @@ def _create_table(
             if name in columns_comments:
                 par["Comment"] = columns_comments[name]
     session: boto3.Session = _utils.ensure_session(session=boto3_session)
-    exist: bool = does_table_exist(database=database, table=table, boto3_session=session)
-    if (mode == "overwrite") or (exist is False):
+
+    if mode == "overwrite":
         delete_table_if_exists(database=database, table=table, boto3_session=session)
-        client_glue: boto3.client = _utils.client(service_name="glue", session=session)
-        client_glue.create_table(DatabaseName=database, TableInput=table_input)
+    client_glue: boto3.client = _utils.client(service_name="glue", session=session)
+    client_glue.create_table(DatabaseName=database, TableInput=table_input)
 
 
 def _csv_table_definition(

--- a/awswrangler/s3.py
+++ b/awswrangler/s3.py
@@ -1730,6 +1730,7 @@ def store_parquet_metadata(
     parameters: Optional[Dict[str, str]] = None,
     columns_comments: Optional[Dict[str, str]] = None,
     compression: Optional[str] = None,
+    mode: str = "overwrite",
     boto3_session: Optional[boto3.Session] = None,
 ) -> Tuple[Dict[str, str], Optional[Dict[str, str]], Optional[Dict[str, List[str]]]]:
     """Infer and store parquet metadata on AWS Glue Catalog.
@@ -1769,6 +1770,8 @@ def store_parquet_metadata(
         Columns names and the related comments (e.g. {'col0': 'Column 0.', 'col1': 'Column 1.', 'col2': 'Partition.'}).
     compression: str, optional
         Compression style (``None``, ``snappy``, ``gzip``, etc).
+    mode: str
+        'overwrite' to recreate any possible existing table or 'append' to keep any possible existing table.
     boto3_session : boto3.Session(), optional
         Boto3 Session. The default boto3 session will be used if boto3_session receive None.
 
@@ -1813,6 +1816,7 @@ def store_parquet_metadata(
         description=description,
         parameters=parameters,
         columns_comments=columns_comments,
+        mode=mode,
         boto3_session=session,
     )
     partitions_values: Dict[str, List[str]] = _data_types.athena_partitions_from_pyarrow_partitions(


### PR DESCRIPTION
# Proposal
I think this behavior is closer to what boto3 api does, since it is not necessary to delete a table to create a new one. In my opinion, the "overwrite" mode should be specified explicitly rather than implicitly.

I find this situation quite problematic when I want to limit the permissions, for instance, to a lambda that will only create tables in glue catalog.
 
# Description of changes
There are changes in two files:

- awswrangler/catalog.py: behavior when creating a non existing parquet table
- awswrangler/s3.py: adding optional mode parameter in store_parquet_metadata method


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.