### PR TITLE
Add chunked=INTEGER option to ensure batch number of rows

### DIFF
--- a/awswrangler/s3.py
+++ b/awswrangler/s3.py
@@ -1501,6 +1501,7 @@ def _read_parquet_init(
         filters=filters,
         read_dictionary=categories,
         validate_schema=validate_schema,
+        split_row_groups=False,
     )
     return data
 
@@ -1510,7 +1511,7 @@ def read_parquet(
     filters: Optional[Union[List[Tuple], List[List[Tuple]]]] = None,
     columns: Optional[List[str]] = None,
     validate_schema: bool = True,
-    chunked: bool = False,
+    chunked: Union[bool, int] = False,
     dataset: bool = False,
     categories: List[str] = None,
     use_threads: bool = True,
@@ -1521,6 +1522,22 @@ def read_parquet(
 
     The concept of Dataset goes beyond the simple idea of files and enable more
     complex features like partitioning and catalog integration (AWS Glue Catalog).
+
+    Note
+    ----
+    ``Batching`` (`chunked` argument) (Memory Friendly):
+
+    Will anable the function to return a Iterable of DataFrames instead of a regular DataFrame.
+
+    There are two batching strategies on Wrangler:
+
+    - If **chunked=True**, a new DataFrame will be returned for each file in your path/dataset.
+
+    - If **chunked=INTEGER**, Wrangler will iterate on the data by number of rows igual the received INTEGER.
+
+    `P.S.` `chunked=True` if faster and uses less memory while `chunked=INTEGER` is more precise
+    in number of rows for each Dataframe.
+
 
     Note
     ----
@@ -1538,11 +1555,12 @@ def read_parquet(
         Check that individual file schemas are all the same / compatible. Schemas within a
         folder prefix should all be the same. Disable if you have schemas that are different
         and want to disable this check.
-    chunked : bool
-        If True will break the data in smaller DataFrames (Non deterministic number of lines).
-        Otherwise return a single DataFrame with the whole data.
+    chunked : Union[int, bool]
+        If passed will split the data in a Iterable of DataFrames (Memory friendly).
+        If `True` wrangler will iterate on the data by files in the most efficient way without guarantee of chunksize.
+        If an `INTEGER` is passed Wrangler will iterate on the data by number of rows igual the received INTEGER.
     dataset: bool
-        If True read a parquet dataset instead of simple file(s) loading all the related partitions as columns.
+        If `True` read a parquet dataset instead of simple file(s) loading all the related partitions as columns.
     categories: List[str], optional
         List of columns names that should be returned as pandas.Categorical.
         Recommended for memory restricted environments.
@@ -1583,12 +1601,19 @@ def read_parquet(
     >>> import awswrangler as wr
     >>> df = wr.s3.read_parquet(path=['s3://bucket/filename0.parquet', 's3://bucket/filename1.parquet'])
 
-    Reading in chunks
+    Reading in chunks (Chunk by file)
 
     >>> import awswrangler as wr
     >>> dfs = wr.s3.read_parquet(path=['s3://bucket/filename0.csv', 's3://bucket/filename1.csv'], chunked=True)
     >>> for df in dfs:
     >>>     print(df)  # Smaller Pandas DataFrame
+
+    Reading in chunks (Chunk by 1MM rows)
+
+    >>> import awswrangler as wr
+    >>> dfs = wr.s3.read_parquet(path=['s3://bucket/filename0.csv', 's3://bucket/filename1.csv'], chunked=1_000_000)
+    >>> for df in dfs:
+    >>>     print(df)  # 1MM Pandas DataFrame
 
     """
     data: pyarrow.parquet.ParquetDataset = _read_parquet_init(
@@ -1596,16 +1621,23 @@ def read_parquet(
         filters=filters,
         dataset=dataset,
         categories=categories,
+        validate_schema=validate_schema,
         use_threads=use_threads,
         boto3_session=boto3_session,
         s3_additional_kwargs=s3_additional_kwargs,
-        validate_schema=validate_schema,
     )
     if chunked is False:
         return _read_parquet(
             data=data, columns=columns, categories=categories, use_threads=use_threads, validate_schema=validate_schema
         )
-    return _read_parquet_chunked(data=data, columns=columns, categories=categories, use_threads=use_threads)
+    return _read_parquet_chunked(
+        data=data,
+        columns=columns,
+        categories=categories,
+        chunked=chunked,
+        use_threads=use_threads,
+        validate_schema=validate_schema,
+    )
 
 
 def _read_parquet(
@@ -1639,22 +1671,50 @@ def _read_parquet_chunked(
     data: pyarrow.parquet.ParquetDataset,
     columns: Optional[List[str]] = None,
     categories: List[str] = None,
+    validate_schema: bool = True,
+    chunked: Union[bool, int] = True,
     use_threads: bool = True,
 ) -> Iterator[pd.DataFrame]:
+    promote: bool = not validate_schema
+    next_slice: Optional[pa.Table] = None
     for piece in data.pieces:
         table: pa.Table = piece.read(
             columns=columns, use_threads=use_threads, partitions=data.partitions, use_pandas_metadata=False
         )
-        yield table.to_pandas(
-            use_threads=use_threads,
-            split_blocks=True,
-            self_destruct=True,
-            integer_object_nulls=False,
-            date_as_object=True,
-            ignore_metadata=True,
-            categories=categories,
-            types_mapper=_data_types.pyarrow2pandas_extension,
-        )
+        if chunked is True:
+            yield _table2df(table=table, categories=categories, use_threads=use_threads)
+        else:
+            if next_slice is not None:
+                table = pa.lib.concat_tables([next_slice, table], promote=promote)
+            length: int = len(table)
+            while True:
+                if length == chunked:
+                    yield _table2df(table=table, categories=categories, use_threads=use_threads)
+                    next_slice = None
+                    break
+                if length < chunked:
+                    next_slice = table
+                    break
+                yield _table2df(
+                    table=table.slice(offset=0, length=chunked), categories=categories, use_threads=use_threads
+                )
+                table = table.slice(offset=chunked, length=None)
+                length = len(table)
+    if next_slice is not None:
+        yield _table2df(table=next_slice, categories=categories, use_threads=use_threads)
+
+
+def _table2df(table: pa.Table, categories: List[str] = None, use_threads: bool = True) -> pd.DataFrame:
+    return table.to_pandas(
+        use_threads=use_threads,
+        split_blocks=True,
+        self_destruct=True,
+        integer_object_nulls=False,
+        date_as_object=True,
+        ignore_metadata=True,
+        categories=categories,
+        types_mapper=_data_types.pyarrow2pandas_extension,
+    )
 
 
 def read_parquet_metadata(
@@ -1972,12 +2032,29 @@ def read_parquet_table(
     filters: Optional[Union[List[Tuple], List[List[Tuple]]]] = None,
     columns: Optional[List[str]] = None,
     categories: List[str] = None,
-    chunked: bool = False,
+    chunked: Union[bool, int] = False,
     use_threads: bool = True,
     boto3_session: Optional[boto3.Session] = None,
     s3_additional_kwargs: Optional[Dict[str, str]] = None,
 ) -> Union[pd.DataFrame, Iterator[pd.DataFrame]]:
     """Read Apache Parquet table registered on AWS Glue Catalog.
+
+    Note
+    ----
+    ``Batching`` (`chunked` argument) (Memory Friendly):
+
+    Will anable the function to return a Iterable of DataFrames instead of a regular DataFrame.
+
+    There are two batching strategies on Wrangler:
+
+    - If **chunked=True**, a new DataFrame will be returned for each file in your path/dataset.
+
+    - If **chunked=INTEGER**, Wrangler will paginate through files slicing and concatenating
+      to return DataFrames with the number of row igual the received INTEGER.
+
+    `P.S.` `chunked=True` if faster and uses less memory while `chunked=INTEGER` is more precise
+    in number of rows for each Dataframe.
+
 
     Note
     ----
@@ -2032,12 +2109,19 @@ def read_parquet_table(
     ...     }
     ... )
 
-    Reading Parquet Table in chunks
+    Reading Parquet Table in chunks (Chunk by file)
 
     >>> import awswrangler as wr
     >>> dfs = wr.s3.read_parquet_table(database='...', table='...', chunked=True)
     >>> for df in dfs:
     >>>     print(df)  # Smaller Pandas DataFrame
+
+    Reading in chunks (Chunk by 1MM rows)
+
+    >>> import awswrangler as wr
+    >>> dfs = wr.s3.read_parquet(path=['s3://bucket/filename0.csv', 's3://bucket/filename1.csv'], chunked=1_000_000)
+    >>> for df in dfs:
+    >>>     print(df)  # 1MM Pandas DataFrame
 
     """
     path: str = catalog.get_table_location(database=database, table=table, boto3_session=boto3_session)

--- a/awswrangler/s3.py
+++ b/awswrangler/s3.py
@@ -1684,23 +1684,15 @@ def _read_parquet_chunked(
         if chunked is True:
             yield _table2df(table=table, categories=categories, use_threads=use_threads)
         else:
-            if next_slice is not None:
+            if next_slice:
                 table = pa.lib.concat_tables([next_slice, table], promote=promote)
-            length: int = len(table)
-            while True:
-                if length == chunked:
-                    yield _table2df(table=table, categories=categories, use_threads=use_threads)
-                    next_slice = None
-                    break
-                if length < chunked:
-                    next_slice = table
-                    break
+            while len(table) >= chunked:
                 yield _table2df(
                     table=table.slice(offset=0, length=chunked), categories=categories, use_threads=use_threads
                 )
                 table = table.slice(offset=chunked, length=None)
-                length = len(table)
-    if next_slice is not None:
+            next_slice = table
+    if next_slice:
         yield _table2df(table=next_slice, categories=categories, use_threads=use_threads)
 
 

--- a/testing/test_awswrangler/test_data_lake.py
+++ b/testing/test_awswrangler/test_data_lake.py
@@ -3,6 +3,7 @@ import datetime
 import gzip
 import logging
 import lzma
+import math
 from io import BytesIO, TextIOWrapper
 
 import boto3
@@ -1084,3 +1085,38 @@ def test_copy(bucket):
 
     wr.s3.delete_objects(path=path)
     wr.s3.delete_objects(path=path2)
+
+
+@pytest.mark.parametrize("col2", [[1, 1, 1, 1, 1], [1, 2, 3, 4, 5], [1, 1, 1, 1, 2], [1, 2, 2, 2, 2]])
+@pytest.mark.parametrize("chunked", [True, 1, 2, 100])
+def test_parquet_chunked(bucket, database, col2, chunked):
+    table = f"test_parquet_chunked_{chunked}_{''.join([str(x) for x in col2])}"
+    path = f"s3://{bucket}/{table}/"
+    wr.s3.delete_objects(path=path)
+    values = list(range(5))
+    df = pd.DataFrame({"col1": values, "col2": col2})
+    paths = wr.s3.to_parquet(
+        df, path, index=False, dataset=True, database=database, table=table, partition_cols=["col2"], mode="overwrite"
+    )["paths"]
+    wr.s3.wait_objects_exist(paths=paths)
+
+    dfs = list(wr.s3.read_parquet(path=path, dataset=True, chunked=chunked))
+    assert sum(values) == pd.concat(dfs, ignore_index=True).col1.sum()
+    if chunked is not True:
+        assert len(dfs) == int(math.ceil(len(df) / chunked))
+        for df2 in dfs[:-1]:
+            assert chunked == len(df2)
+        assert chunked >= len(dfs[-1])
+    else:
+        assert len(dfs) == len(set(col2))
+
+    dfs = list(wr.athena.read_sql_table(database=database, table=table, chunksize=chunked))
+    assert sum(values) == pd.concat(dfs, ignore_index=True).col1.sum()
+    if chunked is not True:
+        assert len(dfs) == int(math.ceil(len(df) / chunked))
+        for df2 in dfs[:-1]:
+            assert chunked == len(df2)
+        assert chunked >= len(dfs[-1])
+
+    wr.s3.delete_objects(path=paths)
+    assert wr.catalog.delete_table_if_exists(database=database, table=table) is True


### PR DESCRIPTION
Issue #192

Add chunked=INTEGER option to ensure batch by number of rows reading Parquet files.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
