### PR TITLE
_utils: Make sure boto3's default session is used

### DIFF
--- a/awswrangler/_utils.py
+++ b/awswrangler/_utils.py
@@ -18,7 +18,9 @@ def ensure_session(session: Optional[boto3.Session] = None) -> boto3.Session:
     """Ensure that a valid boto3.Session will be returned."""
     if session is not None:
         return session
-    return boto3.Session()
+    # Ensure the boto3's default session is used so that its parameters can be
+    # set via boto3.setup_default_session()
+    return boto3._get_default_session()  # pylint: disable=protected-access
 
 
 def client(service_name: str, session: Optional[boto3.Session] = None) -> boto3.client:


### PR DESCRIPTION
*Description of changes:*

* Currently `awswrangler` ensures that at least some boto3 Session is
  used when it calls AWS resources. However, since it creates a
  `boto3.Session()` when non-null boto3 Session is passed as a
  parameter, it completely sidesteps the ability of the user to set
  parameters to the boto3 session that gets used by default (via the
  `boto3.setup_default_session` function).

* This commit ensures that the `ensure_session` function uses boto3's
  default session (reachable via `boto3._get_default_session()`) which
  then also allows `awswrangler` users to set default parameters of the
  boto3 Session it uses by default via `boto3.setup_default_session()`.

Signed-off-by: mr.Shu <mr@shu.io>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

--------

Relevant link: https://boto3.amazonaws.com/v1/documentation/api/latest/_modules/boto3.html#setup_default_session
