### PR TITLE
add test for pandas argument and encoding

### DIFF
--- a/testing/test_awswrangler/test_moto.py
+++ b/testing/test_awswrangler/test_moto.py
@@ -10,6 +10,7 @@ from botocore.exceptions import ClientError
 
 import awswrangler as wr
 from awswrangler.exceptions import EmptyDataFrame, InvalidArgumentCombination
+
 from ._utils import ensure_data_types, get_df_csv, get_df_list
 
 
@@ -220,8 +221,8 @@ def test_csv(s3):
     assert len(df.columns) == 10
 
 
-@mock.patch('pandas.read_csv')
-@mock.patch('s3fs.S3FileSystem.open')
+@mock.patch("pandas.read_csv")
+@mock.patch("s3fs.S3FileSystem.open")
 def test_read_csv_pass_pandas_arguments_and_encoding_succeed(mock_open, mock_read_csv, s3):
     bucket = "bucket"
     key = "foo/foo.csv"
@@ -233,7 +234,7 @@ def test_read_csv_pass_pandas_arguments_and_encoding_succeed(mock_open, mock_rea
         wr.s3.read_csv(path=path, encoding="ISO-8859-1", sep=",", lineterminator="\r\n")
     except TypeError:
         pass
-    mock_open.assert_called_with(path='s3://bucket/foo/foo.csv', mode='r', encoding='ISO-8859-1', newline="\r\n")
+    mock_open.assert_called_with(path="s3://bucket/foo/foo.csv", mode="r", encoding="ISO-8859-1", newline="\r\n")
     mock_read_csv.assert_called_with(ANY, compression=None, encoding="ISO-8859-1", sep=",", lineterminator="\r\n")
 
 

--- a/testing/test_awswrangler/test_moto.py
+++ b/testing/test_awswrangler/test_moto.py
@@ -230,12 +230,10 @@ def test_read_csv_pass_pandas_arguments_and_encoding_succeed(mock_open, mock_rea
     s3_object = s3.Object(bucket, key)
     s3_object.put(Body=b"foo")
 
-    try:
+    with pytest.raises(TypeError):
         wr.s3.read_csv(path=path, encoding="ISO-8859-1", sep=",", lineterminator="\r\n")
-    except TypeError:
-        pass
-    mock_open.assert_called_with(path="s3://bucket/foo/foo.csv", mode="r", encoding="ISO-8859-1", newline="\r\n")
-    mock_read_csv.assert_called_with(ANY, compression=None, encoding="ISO-8859-1", sep=",", lineterminator="\r\n")
+        mock_open.assert_called_with(path="s3://bucket/foo/foo.csv", mode="r", encoding="ISO-8859-1", newline="\r\n")
+        mock_read_csv.assert_called_with(ANY, compression=None, encoding="ISO-8859-1", sep=",", lineterminator="\r\n")
 
 
 def test_to_csv_invalid_argument_combination_raise_when_dataset_false_succeed(s3):


### PR DESCRIPTION
*Issue #, if available:*
add unit test for #271

*Description of changes:*
Add a unit test for testing pandas argument and `encoding` and `newline` argument for the `fs.open` command(https://github.com/awslabs/aws-data-wrangler/blob/b57e2b7245e999191918022341943884e49b2e4e/awswrangler/s3.py#L1654) 

p.s. Because `pandas.read_csv` is in the `pandas.concat` section, a `TypeError` will raise when `concat` get a mock object returned from `pandas.read_csv`. So I used a try catch block to aviod the exception.     

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
