### PR TITLE
Allow providing suffix to s3.store_parquet_metadata

### DIFF
--- a/awswrangler/s3/_read.py
+++ b/awswrangler/s3/_read.py
@@ -25,6 +25,7 @@ def read_parquet_metadata_internal(
     dtype: Optional[Dict[str, str]],
     sampling: float,
     dataset: bool,
+    path_suffix: Optional[str],
     use_threads: bool,
     boto3_session: Optional[boto3.Session],
 ) -> Tuple[Dict[str, str], Optional[Dict[str, str]], Optional[Dict[str, List[str]]]]:
@@ -33,13 +34,13 @@ def read_parquet_metadata_internal(
     if dataset is True:
         if isinstance(path, str):
             _path: Optional[str] = path if path.endswith("/") else f"{path}/"
-            paths: List[str] = path2list(path=_path, boto3_session=session)
+            paths: List[str] = path2list(path=_path, boto3_session=session, suffix=path_suffix)
         else:  # pragma: no cover
             raise exceptions.InvalidArgumentType("Argument <path> must be str if dataset=True.")
     else:
         if isinstance(path, str):
             _path = None
-            paths = path2list(path=path, boto3_session=session)
+            paths = path2list(path=path, boto3_session=session, suffix=path_suffix)
         elif isinstance(path, list):
             _path = None
             paths = path

--- a/awswrangler/s3/_read.py
+++ b/awswrangler/s3/_read.py
@@ -773,7 +773,13 @@ def read_parquet_metadata(
 
     """
     return read_parquet_metadata_internal(
-        path=path, dtype=dtype, sampling=sampling, dataset=dataset, path_suffix=path_suffix, use_threads=use_threads, boto3_session=boto3_session
+        path=path,
+        dtype=dtype,
+        sampling=sampling,
+        dataset=dataset,
+        path_suffix=path_suffix,
+        use_threads=use_threads,
+        boto3_session=boto3_session,
     )[:2]
 
 

--- a/awswrangler/s3/_read.py
+++ b/awswrangler/s3/_read.py
@@ -712,6 +712,7 @@ def read_parquet_metadata(
     dtype: Optional[Dict[str, str]] = None,
     sampling: float = 1.0,
     dataset: bool = False,
+    path_suffix: Optional[str] = None,
     use_threads: bool = True,
     boto3_session: Optional[boto3.Session] = None,
 ) -> Tuple[Dict[str, str], Optional[Dict[str, str]]]:
@@ -739,6 +740,8 @@ def read_parquet_metadata(
         The lower, the faster.
     dataset: bool
         If True read a parquet dataset instead of simple file(s) loading all the related partitions as columns.
+    path_suffix : str
+        Suffix to filter S3 objects found according to the path parameter.
     use_threads : bool
         True to enable concurrent requests, False to disable multiple threads.
         If enabled os.cpu_count() will be used as the max number of threads.
@@ -770,7 +773,7 @@ def read_parquet_metadata(
 
     """
     return read_parquet_metadata_internal(
-        path=path, dtype=dtype, sampling=sampling, dataset=dataset, use_threads=use_threads, boto3_session=boto3_session
+        path=path, dtype=dtype, sampling=sampling, dataset=dataset, path_suffix=path_suffix, use_threads=use_threads, boto3_session=boto3_session
     )[:2]
 
 

--- a/awswrangler/s3/_write.py
+++ b/awswrangler/s3/_write.py
@@ -1059,7 +1059,13 @@ def store_parquet_metadata(  # pylint: disable=too-many-arguments
     partitions_types: Optional[Dict[str, str]]
     partitions_values: Optional[Dict[str, List[str]]]
     columns_types, partitions_types, partitions_values = read_parquet_metadata_internal(
-        path=path, dtype=dtype, sampling=sampling, dataset=dataset, path_suffix=path_suffix, use_threads=use_threads, boto3_session=session
+        path=path,
+        dtype=dtype,
+        sampling=sampling,
+        dataset=dataset,
+        path_suffix=path_suffix,
+        use_threads=use_threads,
+        boto3_session=session,
     )
     _logger.debug("columns_types: %s", columns_types)
     _logger.debug("partitions_types: %s", partitions_types)

--- a/awswrangler/s3/_write.py
+++ b/awswrangler/s3/_write.py
@@ -930,6 +930,7 @@ def store_parquet_metadata(  # pylint: disable=too-many-arguments
     dtype: Optional[Dict[str, str]] = None,
     sampling: float = 1.0,
     dataset: bool = False,
+    path_suffix: Optional[str] = None,
     use_threads: bool = True,
     description: Optional[str] = None,
     parameters: Optional[Dict[str, str]] = None,
@@ -1058,7 +1059,7 @@ def store_parquet_metadata(  # pylint: disable=too-many-arguments
     partitions_types: Optional[Dict[str, str]]
     partitions_values: Optional[Dict[str, List[str]]]
     columns_types, partitions_types, partitions_values = read_parquet_metadata_internal(
-        path=path, dtype=dtype, sampling=sampling, dataset=dataset, use_threads=use_threads, boto3_session=session
+        path=path, dtype=dtype, sampling=sampling, dataset=dataset, path_suffix=path_suffix, use_threads=use_threads, boto3_session=session
     )
     _logger.debug("columns_types: %s", columns_types)
     _logger.debug("partitions_types: %s", partitions_types)


### PR DESCRIPTION
*Description of changes:*
Expose `path_suffix` argument in `s3.store_parquet_metadata` function to allow filtering to specific file types under the root prefix.  This would support a use-case of ours in which we store a custom metadata file alongside folders containing Parquet files. Like:
```
root/
    .custom_meta
    partition=1/
        foo.parquet
    partition=2/
        bar.parquet
```

Such a layout is already supported by PyArrow (ie, calling `pyarrow.parquet.ParquetDataset("s3://<bucket>/root/")` works fine), but since `awswrangler` tries to interpret every file/folder under `root/` as its own ParquetDataset, things break. In the above example, we would provide a `path_suffix=".parquet"`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
