### PR TITLE
setting dtype to decimal results in "StringArray requires a sequence of strings or pandas.NA" error

### DIFF
--- a/awswrangler/_data_types.py
+++ b/awswrangler/_data_types.py
@@ -455,7 +455,7 @@ def _cast_pandas_column(df: pd.DataFrame, col: str, current_type: str, desired_t
     elif desired_type == "decimal":
         df[col] = (
             df[col]
-            .astype("string")
+            .astype("str")
             .apply(lambda x: Decimal(str(x)) if str(x) not in ("", "none", "None", " ", "<NA>") else None)
         )
     elif desired_type == "string":


### PR DESCRIPTION
astype("string") does not allow numeric characters so it seems to be a bug where we are casting a field that we want to be a decimal as a "string". We should use "str" instead.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
