### PR TITLE
F/athena query add metadata

### DIFF
--- a/awswrangler/athena/_read.py
+++ b/awswrangler/athena/_read.py
@@ -20,6 +20,7 @@ from awswrangler.athena._utils import (
     _QueryMetadata,
     _start_query_execution,
     _WorkGroupConfig,
+    _empty_dataframe_response,
 )
 
 _logger: logging.Logger = logging.getLogger(__name__)
@@ -47,6 +48,13 @@ def _fix_csv_types_generator(
     for df in dfs:
         yield _fix_csv_types(df=df, parse_dates=parse_dates, binaries=binaries)
 
+def _add_query_metadata_generator(
+    dfs: Iterator[pd.DataFrame], query_metadata: _QueryMetadata
+) -> Iterator[pd.DataFrame]:
+    """Add Query Execution metadata to every DF in iterator."""
+    for df in dfs:
+        df.query_metadata = query_metadata
+        yield df
 
 def _fix_csv_types(df: pd.DataFrame, parse_dates: List[str], binaries: List[str]) -> pd.DataFrame:
     """Apply data types cast to a Pandas DataFrames."""
@@ -204,7 +212,7 @@ def _fetch_parquet_result(
     chunked: Union[bool, int] = False if chunksize is None else chunksize
     _logger.debug("chunked: %s", chunked)
     if query_metadata.manifest_location is None:
-        return pd.DataFrame() if chunked is False else _utils.empty_generator()
+        return _empty_dataframe_response(chunked, query_metadata)
     manifest_path: str = query_metadata.manifest_location
     metadata_path: str = manifest_path.replace("-manifest.csv", ".metadata")
     _logger.debug("manifest_path: %s", manifest_path)
@@ -212,11 +220,15 @@ def _fetch_parquet_result(
     s3.wait_objects_exist(paths=[manifest_path], use_threads=False, boto3_session=boto3_session)
     paths: List[str] = _extract_ctas_manifest_paths(path=manifest_path, boto3_session=boto3_session)
     if not paths:
-        return pd.DataFrame() if chunked is False else _utils.empty_generator()
+        return _empty_dataframe_response(chunked, query_metadata)
     s3.wait_objects_exist(paths=paths, use_threads=False, boto3_session=boto3_session)
     ret = s3.read_parquet(
         path=paths, use_threads=use_threads, boto3_session=boto3_session, chunked=chunked, categories=categories
     )
+    if chunked is False:
+        ret.query_metadata = query_metadata
+    else:
+        ret = _add_query_metadata_generator(dfs=ret, query_metadata=query_metadata)
     paths_delete: List[str] = paths + [manifest_path, metadata_path]
     _logger.debug("type(ret): %s", type(ret))
     if chunked is False:
@@ -238,7 +250,8 @@ def _fetch_csv_result(
     _chunksize: Optional[int] = chunksize if isinstance(chunksize, int) else None
     _logger.debug("_chunksize: %s", _chunksize)
     if query_metadata.output_location is None or query_metadata.output_location.endswith(".csv") is False:
-        return pd.DataFrame() if _chunksize is None else _utils.empty_generator()
+        chunked = _chunksize is not None
+        return _empty_dataframe_response(chunked, query_metadata)
     path: str = query_metadata.output_location
     s3.wait_objects_exist(paths=[path], use_threads=False, boto3_session=boto3_session)
     _logger.debug("Start CSV reading from %s", path)
@@ -259,10 +272,12 @@ def _fetch_csv_result(
     _logger.debug(type(ret))
     if _chunksize is None:
         df = _fix_csv_types(df=ret, parse_dates=query_metadata.parse_dates, binaries=query_metadata.binaries)
+        df.query_metadata = query_metadata
         if keep_files is False:
             s3.delete_objects(path=[path, f"{path}.metadata"], use_threads=use_threads, boto3_session=boto3_session)
         return df
     dfs = _fix_csv_types_generator(dfs=ret, parse_dates=query_metadata.parse_dates, binaries=query_metadata.binaries)
+    dfs = _add_query_metadata_generator(dfs=dfs, query_metadata=query_metadata)
     if keep_files is False:
         return _delete_after_iterate(
             dfs=dfs, paths=[path, f"{path}.metadata"], use_threads=use_threads, boto3_session=boto3_session

--- a/awswrangler/athena/_utils.py
+++ b/awswrangler/athena/_utils.py
@@ -5,6 +5,7 @@ import pprint
 import time
 from decimal import Decimal
 from typing import Any, Dict, Iterator, List, NamedTuple, Optional, Union
+from datetime import datetime
 
 import boto3  # type: ignore
 import pandas as pd  # type: ignore
@@ -20,6 +21,14 @@ _logger: logging.Logger = logging.getLogger(__name__)
 
 class _QueryMetadata(NamedTuple):
     execution_id: str
+    query: str
+    statement_type: str
+    encryption_configuration: Optional[Dict[str, str]]
+    query_execution_context: Optional[Dict[str, str]]
+    athena_submission_datetime: datetime
+    athena_completion_datetime: datetime
+    athena_statistics: Dict[str, Union[int, str]]
+    workgroup: str
     dtype: Dict[str, str]
     parse_timestamps: List[str]
     parse_dates: List[str]
@@ -203,16 +212,40 @@ def _get_query_metadata(
             converters[col_name] = lambda x: Decimal(str(x)) if str(x) not in ("", "none", " ", "<NA>") else None
         else:
             dtype[col_name] = pandas_type
+
     output_location: Optional[str] = None
+    encryption_configuration: Optional[Dict[str, str]] = {}
     if "ResultConfiguration" in _query_execution_payload:
         if "OutputLocation" in _query_execution_payload["ResultConfiguration"]:
             output_location = _query_execution_payload["ResultConfiguration"]["OutputLocation"]
+        if "EncryptionConfiguration" in _query_execution_payload["ResultConfiguration"]:
+            encryption_configuration = _query_execution_payload["ResultConfiguration"]["EncryptionConfiguration"]
+
     manifest_location: Optional[str] = None
+    athena_statistics: Dict[str, Union[int, str]] = {}
     if "Statistics" in _query_execution_payload:
+        athena_statistics = _query_execution_payload["Statistics"]
         if "DataManifestLocation" in _query_execution_payload["Statistics"]:
             manifest_location = _query_execution_payload["Statistics"]["DataManifestLocation"]
+            del athena_statistics["DataManifestLocation"]
+
+    athena_submission_datetime: Optional[datetime] = _query_execution_payload["Status"].get("SubmissionDateTime")
+    athena_completion_datetime: Optional[datetime] =  _query_execution_payload["Status"].get("CompletionDateTime")
+    query_execution_context: Optional[Dict[str, str]] = _query_execution_payload.get("QueryExecutionContext")
+    query: str = _query_execution_payload["Query"]
+    statement_type: str = _query_execution_payload["StatementType"]    
+    workgroup: str = _query_execution_payload["WorkGroup"]
+
     query_metadata: _QueryMetadata = _QueryMetadata(
         execution_id=query_execution_id,
+        query=query,
+        statement_type=statement_type,
+        encryption_configuration=encryption_configuration,
+        query_execution_context=query_execution_context,
+        athena_submission_datetime=athena_submission_datetime,
+        athena_completion_datetime=athena_completion_datetime,
+        athena_statistics=athena_statistics,
+        workgroup=workgroup,
         dtype=dtype,
         parse_timestamps=parse_timestamps,
         parse_dates=parse_dates,
@@ -224,6 +257,14 @@ def _get_query_metadata(
     _logger.debug("query_metadata:\n%s", query_metadata)
     return query_metadata
 
+def _empty_dataframe_response(chunked: bool, query_metadata: _QueryMetadata):
+    # TODO: test this
+    "Generate an empty dataframe response"
+    if chunked is False:
+        df = pd.DataFrame()
+        df.query_metadata = query_metadata
+        return df
+    return _utils.empty_generator()
 
 def get_query_columns_types(query_execution_id: str, boto3_session: Optional[boto3.Session] = None) -> Dict[str, str]:
     """Get the data type of all columns queried.

--- a/awswrangler/athena/_utils.py
+++ b/awswrangler/athena/_utils.py
@@ -3,9 +3,9 @@ import csv
 import logging
 import pprint
 import time
+from datetime import datetime
 from decimal import Decimal
 from typing import Any, Dict, Iterator, List, NamedTuple, Optional, Union
-from datetime import datetime
 
 import boto3  # type: ignore
 import pandas as pd  # type: ignore
@@ -162,7 +162,7 @@ def _parse_describe_table(df: pd.DataFrame) -> pd.DataFrame:
     return pd.DataFrame(data=target_df_dict)
 
 
-def _get_query_metadata(
+def _get_query_metadata(  # pylint: disable=too-many-statements
     query_execution_id: str,
     boto3_session: boto3.Session,
     categories: List[str] = None,
@@ -229,11 +229,11 @@ def _get_query_metadata(
             manifest_location = _query_execution_payload["Statistics"]["DataManifestLocation"]
             del athena_statistics["DataManifestLocation"]
 
-    athena_submission_datetime: Optional[datetime] = _query_execution_payload["Status"].get("SubmissionDateTime")
-    athena_completion_datetime: Optional[datetime] =  _query_execution_payload["Status"].get("CompletionDateTime")
+    athena_submission_datetime: datetime = _query_execution_payload["Status"].get("SubmissionDateTime")
+    athena_completion_datetime: datetime = _query_execution_payload["Status"].get("CompletionDateTime")
     query_execution_context: Optional[Dict[str, str]] = _query_execution_payload.get("QueryExecutionContext")
     query: str = _query_execution_payload["Query"]
-    statement_type: str = _query_execution_payload["StatementType"]    
+    statement_type: str = _query_execution_payload["StatementType"]
     workgroup: str = _query_execution_payload["WorkGroup"]
 
     query_metadata: _QueryMetadata = _QueryMetadata(
@@ -257,14 +257,15 @@ def _get_query_metadata(
     _logger.debug("query_metadata:\n%s", query_metadata)
     return query_metadata
 
+
 def _empty_dataframe_response(chunked: bool, query_metadata: _QueryMetadata):
-    # TODO: test this
-    "Generate an empty dataframe response"
+    """Generate an empty dataframe response."""
     if chunked is False:
         df = pd.DataFrame()
         df.query_metadata = query_metadata
         return df
     return _utils.empty_generator()
+
 
 def get_query_columns_types(query_execution_id: str, boto3_session: Optional[boto3.Session] = None) -> Dict[str, str]:
     """Get the data type of all columns queried.

--- a/tests/_utils.py
+++ b/tests/_utils.py
@@ -9,6 +9,7 @@ import pandas as pd
 
 import awswrangler as wr
 from awswrangler._utils import try_it
+from awswrangler.athena._utils import _QueryMetadata
 
 ts = lambda x: datetime.strptime(x, "%Y-%m-%d %H:%M:%S.%f")  # noqa
 dt = lambda x: datetime.strptime(x, "%Y-%m-%d").date()  # noqa
@@ -487,6 +488,24 @@ def ensure_data_types_csv(df):
         assert str(df["par0"].dtype).startswith("Int")
     if "par1" in df:
         assert str(df["par1"].dtype) == "string"
+
+
+def ensure_athena_query_metadata(df, ctas_approach=True, encrypted=False):
+    assert df.query_metadata is not None
+    assert isinstance(df.query_metadata, _QueryMetadata)
+    assert df.query_metadata.execution_id is not None
+    assert df.query_metadata.query is not None
+    assert df.query_metadata.statement_type is not None
+    if encrypted:
+        assert df.query_metadata.encryption_configuration
+    assert df.query_metadata.query_execution_context is not None
+    assert df.query_metadata.athena_submission_datetime is not None
+    assert df.query_metadata.athena_completion_datetime is not None
+    assert df.query_metadata.athena_statistics is not None
+    assert df.query_metadata.workgroup is not None
+    assert df.query_metadata.output_location is not None
+    if ctas_approach:
+        assert df.query_metadata.manifest_location is not None
 
 
 def get_time_str_with_random_suffix():

--- a/tests/test_athena_cache.py
+++ b/tests/test_athena_cache.py
@@ -5,6 +5,8 @@ import pandas as pd
 
 import awswrangler as wr
 
+from ._utils import ensure_athena_query_metadata
+
 logging.basicConfig(level=logging.INFO, format="[%(asctime)s][%(levelname)s][%(name)s][%(funcName)s] %(message)s")
 logging.getLogger("awswrangler").setLevel(logging.DEBUG)
 logging.getLogger("botocore.credentials").setLevel(logging.CRITICAL)
@@ -64,6 +66,7 @@ def test_cache_query_ctas_approach_true(path, glue_database, glue_table):
         resolve_no_cache.assert_not_called()
         assert df.shape == df3.shape
         assert df.c0.sum() == df3.c0.sum()
+        ensure_athena_query_metadata(df=df3, ctas_approach=True, encrypted=False)
 
 
 def test_cache_query_ctas_approach_false(path, glue_database, glue_table):
@@ -95,6 +98,7 @@ def test_cache_query_ctas_approach_false(path, glue_database, glue_table):
         resolve_no_cache.assert_not_called()
         assert df.shape == df3.shape
         assert df.c0.sum() == df3.c0.sum()
+        ensure_athena_query_metadata(df=df3, ctas_approach=False, encrypted=False)
 
 
 def test_cache_query_semicolon(path, glue_database, glue_table):


### PR DESCRIPTION
*Issue #, if available:* #312 

*Description of changes:*
When calling Athena's `read_sql_query`, the resulting DataFrame (or every DataFrame in the returned Iterator) will have a `query_metadata` attribute, which brings the query result metadata returned by Athena.

Assumptions made:

- For nested metadata (such as the `Statistics` object), we do not correct casing on every subitem (as Athena's metadata is originally in CamelCase). This may be a little weird when accessing the data, but does not inflate the code with lots of casing-corrections or add new dependencies for it.
- Nothing was added on README or any other docfile, I don't know the best place to announce that metadata info :)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
