### PR TITLE
Add OKRA to "Who uses"

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,3 +125,4 @@ Please send a PR with your company name and @githubhandle if you may.
 3. [M4U](https://www.m4u.com.br/) [[@Thiago-Dantas](https://github.com/Thiago-Dantas)]
 4. [Serasa Experian](https://www.serasaexperian.com.br/) [[@andre-marcos-perez](https://github.com/andre-marcos-perez)]
 5. [LINE TV](https://www.linetv.tw/) [[@bryanyang0528](https://github.com/bryanyang0528)]
+6. [OKRA Technologies](https://okra.ai) [[@JPFrancoia](https://github.com/JPFrancoia), [@schot](https://github.com/schot)]


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Add OKRA Technologies to "Who uses AWS Data Wrangler?"

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
