### PR TITLE
Update get_table_types example

### DIFF
--- a/awswrangler/catalog/_get.py
+++ b/awswrangler/catalog/_get.py
@@ -119,7 +119,7 @@ def get_table_types(
     Examples
     --------
     >>> import awswrangler as wr
-    >>> wr.catalog.get_table_types(database='default', name='my_table')
+    >>> wr.catalog.get_table_types(database='default', table='my_table')
     {'col0': 'int', 'col1': double}
 
     """


### PR DESCRIPTION
*Issue #, if available:*
get_table_types example was failing with TypeError: got an unexpected keyword argument 'name' 

*Description of changes:*
Updated get_table_types example to correct arg name "table"

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
