### PR TITLE
Add support for extra s3 args to copy_objects()

### DIFF
--- a/awswrangler/s3/_copy.py
+++ b/awswrangler/s3/_copy.py
@@ -13,7 +13,8 @@ from awswrangler.s3._list import list_objects
 _logger: logging.Logger = logging.getLogger(__name__)
 
 
-def _copy_objects(batch: List[Tuple[str, str]], use_threads: bool, boto3_session: boto3.Session, s3_additional_kwargs: Optional[Dict[str, str]]) -> None:
+def _copy_objects(batch: List[Tuple[str, str]], use_threads: bool,
+                  boto3_session: boto3.Session, s3_additional_kwargs: Optional[Dict[str, str]]) -> None:
     _logger.debug("len(batch): %s", len(batch))
     client_s3: boto3.client = _utils.client(service_name="s3", session=boto3_session)
     resource_s3: boto3.resource = _utils.resource(service_name="s3", session=boto3_session)
@@ -114,7 +115,8 @@ def merge_datasets(
         raise exceptions.InvalidArgumentValue(f"{mode} is a invalid mode option.")
 
     new_objects: List[str] = copy_objects(
-        paths=paths, source_path=source_path, target_path=target_path, use_threads=use_threads, boto3_session=session, s3_additional_kwargs=s3_additional_kwargs
+        paths=paths, source_path=source_path, target_path=target_path,
+        use_threads=use_threads, boto3_session=session, s3_additional_kwargs=s3_additional_kwargs
     )
     _logger.debug("len(new_objects): %s", len(new_objects))
     return new_objects
@@ -199,5 +201,8 @@ def copy_objects(
         new_objects.append(path_final)
         batch.append((path, path_final))
     _logger.debug("len(new_objects): %s", len(new_objects))
-    _copy_objects(batch=batch, use_threads=use_threads, boto3_session=session, s3_additional_kwargs=s3_additional_kwargs)
+    _copy_objects(
+        batch=batch, use_threads=use_threads,
+        boto3_session=session, s3_additional_kwargs=s3_additional_kwargs
+    )
     return new_objects

--- a/awswrangler/s3/_copy.py
+++ b/awswrangler/s3/_copy.py
@@ -13,7 +13,7 @@ from awswrangler.s3._list import list_objects
 _logger: logging.Logger = logging.getLogger(__name__)
 
 
-def _copy_objects(batch: List[Tuple[str, str]], s3_additional_kwargs: Optional[Dict[str, str]], use_threads: bool, boto3_session: boto3.Session) -> None:
+def _copy_objects(batch: List[Tuple[str, str]], use_threads: bool, boto3_session: boto3.Session, s3_additional_kwargs: Optional[Dict[str, str]]) -> None:
     _logger.debug("len(batch): %s", len(batch))
     client_s3: boto3.client = _utils.client(service_name="s3", session=boto3_session)
     resource_s3: boto3.resource = _utils.resource(service_name="s3", session=boto3_session)
@@ -125,9 +125,9 @@ def copy_objects(
     source_path: str,
     target_path: str,
     replace_filenames: Optional[Dict[str, str]] = None,
-    s3_additional_kwargs: Optional[Dict[str, str]] = None,
     use_threads: bool = True,
     boto3_session: Optional[boto3.Session] = None,
+    s3_additional_kwargs: Optional[Dict[str, str]] = None,
 ) -> List[str]:
     """Copy a list of S3 objects to another S3 directory.
 

--- a/awswrangler/s3/_copy.py
+++ b/awswrangler/s3/_copy.py
@@ -13,8 +13,12 @@ from awswrangler.s3._list import list_objects
 _logger: logging.Logger = logging.getLogger(__name__)
 
 
-def _copy_objects(batch: List[Tuple[str, str]], use_threads: bool,
-                  boto3_session: boto3.Session, s3_additional_kwargs: Optional[Dict[str, str]]) -> None:
+def _copy_objects(
+    batch: List[Tuple[str, str]],
+    use_threads: bool,
+    boto3_session: boto3.Session,
+    s3_additional_kwargs: Optional[Dict[str, str]],
+) -> None:
     _logger.debug("len(batch): %s", len(batch))
     client_s3: boto3.client = _utils.client(service_name="s3", session=boto3_session)
     resource_s3: boto3.resource = _utils.resource(service_name="s3", session=boto3_session)
@@ -115,8 +119,12 @@ def merge_datasets(
         raise exceptions.InvalidArgumentValue(f"{mode} is a invalid mode option.")
 
     new_objects: List[str] = copy_objects(
-        paths=paths, source_path=source_path, target_path=target_path,
-        use_threads=use_threads, boto3_session=session, s3_additional_kwargs=s3_additional_kwargs
+        paths=paths,
+        source_path=source_path,
+        target_path=target_path,
+        use_threads=use_threads,
+        boto3_session=session,
+        s3_additional_kwargs=s3_additional_kwargs,
     )
     _logger.debug("len(new_objects): %s", len(new_objects))
     return new_objects
@@ -202,7 +210,6 @@ def copy_objects(
         batch.append((path, path_final))
     _logger.debug("len(new_objects): %s", len(new_objects))
     _copy_objects(
-        batch=batch, use_threads=use_threads,
-        boto3_session=session, s3_additional_kwargs=s3_additional_kwargs
+        batch=batch, use_threads=use_threads, boto3_session=session, s3_additional_kwargs=s3_additional_kwargs
     )
     return new_objects


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- This PR is to add support for specifying extra s3 arguments to `copy_objects()`, the arguments get passed to the `ExtraArgs` in `boto3.resource('s3').meta.client.copy()` 
- Tested using `Mocked test environment` and the tests are passing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
