### PR TITLE
Fix example args in def table()

### DIFF
--- a/awswrangler/catalog/_get.py
+++ b/awswrangler/catalog/_get.py
@@ -425,7 +425,7 @@ def table(
     Examples
     --------
     >>> import awswrangler as wr
-    >>> df_table = wr.catalog.table(database='default', name='my_table')
+    >>> df_table = wr.catalog.table(database='default', table='my_table')
 
     """
     client_glue: boto3.client = _utils.client(service_name="glue", session=boto3_session)


### PR DESCRIPTION
Fix arg name from "name" to "table". 
Issue: 

*Issue #, if available:*
*Description of changes:*
Fix arg name from "name" to "table". In function table(), the args for table is "table" instead of "name". The example was leading to error: "TypeError: table() got an unexpected keyword argument 'name'"


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
