### PR TITLE
Feature/copy creds

### DIFF
--- a/awswrangler/_utils.py
+++ b/awswrangler/_utils.py
@@ -232,6 +232,15 @@ def get_region_from_session(boto3_session: Optional[boto3.Session] = None, defau
     raise exceptions.InvalidArgument("There is no region_name defined on boto3, please configure it.")
 
 
+def get_credentials_from_session(
+        boto3_session: Optional[boto3.Session] = None
+) -> botocore.credentials.ReadOnlyCredentials:
+    session: boto3.Session = ensure_session(session=boto3_session)
+    credentials: botocore.credentials.Credentials = session.get_credentials()
+    frozen_credentials: botocore.credentials.ReadOnlyCredentials = credentials.get_frozen_credentials()
+    return frozen_credentials
+
+
 def list_sampling(lst: List[Any], sampling: float) -> List[Any]:
     """Random List sampling."""
     if sampling == 1.0:

--- a/awswrangler/_utils.py
+++ b/awswrangler/_utils.py
@@ -233,7 +233,7 @@ def get_region_from_session(boto3_session: Optional[boto3.Session] = None, defau
 
 
 def get_credentials_from_session(
-        boto3_session: Optional[boto3.Session] = None
+    boto3_session: Optional[boto3.Session] = None,
 ) -> botocore.credentials.ReadOnlyCredentials:
     """Get AWS credentials from boto3 session."""
     session: boto3.Session = ensure_session(session=boto3_session)

--- a/awswrangler/_utils.py
+++ b/awswrangler/_utils.py
@@ -235,6 +235,7 @@ def get_region_from_session(boto3_session: Optional[boto3.Session] = None, defau
 def get_credentials_from_session(
         boto3_session: Optional[boto3.Session] = None
 ) -> botocore.credentials.ReadOnlyCredentials:
+    """Get AWS credentials from boto3 session."""
     session: boto3.Session = ensure_session(session=boto3_session)
     credentials: botocore.credentials.Credentials = session.get_credentials()
     frozen_credentials: botocore.credentials.ReadOnlyCredentials = credentials.get_frozen_credentials()

--- a/awswrangler/redshift.py
+++ b/awswrangler/redshift.py
@@ -430,6 +430,9 @@ def connect_temp(
         Default: 900
     auto_create : bool
         Create a database user with the name specified for the user named in user if one does not exist.
+    db_groups : List[str], optional
+        A list of the names of existing database groups that the user named in user will join for the current session,
+        in addition to any group memberships for an existing user. If not specified, a new user is added only to PUBLIC.
     boto3_session : boto3.Session(), optional
         Boto3 Session. The default boto3 session will be used if boto3_session receive None.
     ssl: bool
@@ -772,7 +775,7 @@ def unload_to_files(
     con : redshift_connector.Connection
         Use redshift_connector.connect() to use "
         "credentials directly or wr.redshift.connect() to fetch it from the Glue Catalog.
-    iam_role : str
+    iam_role : str, optional
         AWS IAM role with the related permissions.
     region : str, optional
         Specifies the AWS Region where the target Amazon S3 bucket is located.
@@ -852,7 +855,7 @@ def unload(
     sql: str,
     path: str,
     con: redshift_connector.Connection,
-    iam_role: str,
+    iam_role: Optional[str],
     region: Optional[str] = None,
     max_file_size: Optional[float] = None,
     kms_key_id: Optional[str] = None,
@@ -905,7 +908,7 @@ def unload(
     con : redshift_connector.Connection
         Use redshift_connector.connect() to use "
         "credentials directly or wr.redshift.connect() to fetch it from the Glue Catalog.
-    iam_role : str
+    iam_role : str, optional
         AWS IAM role with the related permissions.
     region : str, optional
         Specifies the AWS Region where the target Amazon S3 bucket is located.
@@ -1040,7 +1043,7 @@ def copy_from_files(  # pylint: disable=too-many-locals,too-many-arguments
         Table name
     schema : str
         Schema name
-    iam_role : str
+    iam_role : str, optional
         AWS IAM role with the related permissions.
     parquet_infer_sampling : float
         Random sample ratio of files that will have the metadata inspected.
@@ -1210,7 +1213,7 @@ def copy(  # pylint: disable=too-many-arguments
         Table name
     schema : str
         Schema name
-    iam_role : str
+    iam_role : str, optional
         AWS IAM role with the related permissions.
     index : bool
         True to store the DataFrame index in file, otherwise False to ignore it.

--- a/awswrangler/redshift.py
+++ b/awswrangler/redshift.py
@@ -60,13 +60,10 @@ def _make_s3_auth_string(
     aws_secret_access_key: Optional[str] = None,
     aws_session_token: Optional[str] = None,
     iam_role: Optional[str] = None,
-    boto3_session: Optional[boto3.Session] = None
+    boto3_session: Optional[boto3.Session] = None,
 ) -> str:
     if aws_access_key_id is not None and aws_secret_access_key is not None:
-        auth_str: str = (
-            f"ACCESS_KEY_ID '{aws_access_key_id}'\n"
-            f"SECRET_ACCESS_KEY '{aws_secret_access_key}'\n"
-        )
+        auth_str: str = f"ACCESS_KEY_ID '{aws_access_key_id}'\n" f"SECRET_ACCESS_KEY '{aws_secret_access_key}'\n"
         if aws_session_token is not None:
             auth_str += f"SESSION_TOKEN '{aws_session_token}'\n"
     elif iam_role is not None:
@@ -76,14 +73,13 @@ def _make_s3_auth_string(
         credentials: botocore.credentials.ReadOnlyCredentials
         credentials = _utils.get_credentials_from_session(boto3_session=boto3_session)
         if credentials.access_key is None or credentials.secret_key is None:
-            raise exceptions.InvalidArgument("One of IAM Role or AWS ACCESS_KEY_ID and SECRET_ACCESS_KEY must be "
-                                             "given. Unable to find ACCESS_KEY_ID and SECRET_ACCESS_KEY in boto3 "
-                                             "session.")
+            raise exceptions.InvalidArgument(
+                "One of IAM Role or AWS ACCESS_KEY_ID and SECRET_ACCESS_KEY must be "
+                "given. Unable to find ACCESS_KEY_ID and SECRET_ACCESS_KEY in boto3 "
+                "session."
+            )
 
-        auth_str = (
-            f"ACCESS_KEY_ID '{credentials.access_key}'\n"
-            f"SECRET_ACCESS_KEY '{credentials.secret_key}'\n"
-        )
+        auth_str = f"ACCESS_KEY_ID '{credentials.access_key}'\n" f"SECRET_ACCESS_KEY '{credentials.secret_key}'\n"
         if credentials.token is not None:
             auth_str += f"SESSION_TOKEN '{credentials.token}'\n"
 
@@ -103,10 +99,7 @@ def _copy(
     else:
         table_name = f'"{schema}"."{table}"'
 
-    auth_str: str = _make_s3_auth_string(
-        iam_role=iam_role,
-        boto3_session=boto3_session
-    )
+    auth_str: str = _make_s3_auth_string(iam_role=iam_role, boto3_session=boto3_session)
     sql: str = f"COPY {table_name} FROM '{path}'{auth_str}\nFORMAT AS PARQUET"
     _logger.debug("copy query:\n%s", sql)
     cursor.execute(sql)
@@ -828,10 +821,7 @@ def unload_to_files(
         max_file_size_str: str = f"\nMAXFILESIZE AS {max_file_size} MB" if max_file_size is not None else ""
         kms_key_id_str: str = f"\nKMS_KEY_ID '{kms_key_id}'" if kms_key_id is not None else ""
 
-        auth_str: str = _make_s3_auth_string(
-            iam_role=iam_role,
-            boto3_session=boto3_session
-        )
+        auth_str: str = _make_s3_auth_string(iam_role=iam_role, boto3_session=boto3_session)
 
         sql = (
             f"UNLOAD ('{sql}')\n"
@@ -1140,7 +1130,7 @@ def copy_from_files(  # pylint: disable=too-many-locals,too-many-arguments
                 table=created_table,
                 schema=created_schema,
                 iam_role=iam_role,
-                boto3_session=boto3_session
+                boto3_session=boto3_session,
             )
             if table != created_table:  # upsert
                 _upsert(cursor=cursor, schema=schema, table=table, temp_table=created_table, primary_keys=primary_keys)

--- a/awswrangler/redshift.py
+++ b/awswrangler/redshift.py
@@ -63,7 +63,7 @@ def _make_s3_auth_string(
     boto3_session: Optional[boto3.Session] = None,
 ) -> str:
     if aws_access_key_id is not None and aws_secret_access_key is not None:
-        auth_str: str = f"ACCESS_KEY_ID '{aws_access_key_id}'\n" f"SECRET_ACCESS_KEY '{aws_secret_access_key}'\n"
+        auth_str: str = f"ACCESS_KEY_ID '{aws_access_key_id}'\nSECRET_ACCESS_KEY '{aws_secret_access_key}'\n"
         if aws_session_token is not None:
             auth_str += f"SESSION_TOKEN '{aws_session_token}'\n"
     elif iam_role is not None:
@@ -79,7 +79,7 @@ def _make_s3_auth_string(
                 "session."
             )
 
-        auth_str = f"ACCESS_KEY_ID '{credentials.access_key}'\n" f"SECRET_ACCESS_KEY '{credentials.secret_key}'\n"
+        auth_str = f"ACCESS_KEY_ID '{credentials.access_key}'\nSECRET_ACCESS_KEY '{credentials.secret_key}'\n"
         if credentials.token is not None:
             auth_str += f"SESSION_TOKEN '{credentials.token}'\n"
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,11 +6,11 @@ mypy==0.790
 pydocstyle==5.1.1
 doc8==0.8.1
 tox==3.20.1
-pytest==6.1.2
+pytest==6.2.1
 pytest-cov==2.10.1
-pytest-xdist==2.1.0
+pytest-xdist==2.2.0
 pytest-timeout==1.4.2
-cfn-lint~=0.43.0
+cfn-lint~=0.44.0
 pydot~=1.4.1
 cfn-flip==1.2.3
 twine==3.2.0


### PR DESCRIPTION
Related to Issue #484 

*Description of changes:*
Allow users to use the credentials in a passed boto3 session (or default boto3 session) to authenticate unloading redshift data to s3. Users should have s3 permissions already to do many s3 operations. Can easily add allowing passing raw credentials if desired.

There was also a bug fix in copy where a boto3 session was not passed.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
