### PR TITLE
Add params to athena sql

### DIFF
--- a/awswrangler/athena/_read.py
+++ b/awswrangler/athena/_read.py
@@ -691,6 +691,12 @@ def read_sql_query(
     >>> df = wr.athena.read_sql_query(sql="...", database="...")
     >>> scanned_bytes = df.query_metadata["Statistics"]["DataScannedInBytes"]
 
+    >>> import awswrangler as wr
+    >>> df = wr.athena.read_sql_query(
+    ...     sql="SELECT * FROM my_table WHERE name=:name;",
+    ...     params={"name": "filtered_name"}
+    ... )
+
     """
     if ctas_approach and data_source not in (None, "AwsDataCatalog"):
         raise exceptions.InvalidArgumentCombination(

--- a/awswrangler/athena/_read.py
+++ b/awswrangler/athena/_read.py
@@ -533,6 +533,7 @@ def read_sql_query(
     max_cache_seconds: int = 0,
     max_cache_query_inspections: int = 50,
     data_source: Optional[str] = None,
+    params: Optional[Dict[str, Any]] = None,
 ) -> Union[pd.DataFrame, Iterator[pd.DataFrame]]:
     """Execute any SQL query on AWS Athena and return the results as a Pandas DataFrame.
 
@@ -679,6 +680,10 @@ def read_sql_query(
         Only takes effect if max_cache_seconds > 0.
     data_source : str, optional
         Data Source / Catalog name. If None, 'AwsDataCatalog' will be used by default.
+    params: Dict[str, any], optional
+        Dict of parameters that will be used for constructing the SQL query. Only named parameters are supported.
+        The dict needs to contain the information in the form {'name': 'value'} and the SQL query needs to contain
+        `:name;`.
 
     Returns
     -------
@@ -708,6 +713,10 @@ def read_sql_query(
         )
     chunksize = sys.maxsize if ctas_approach is False and chunksize is True else chunksize
     session: boto3.Session = _utils.ensure_session(session=boto3_session)
+    if params is None:
+        params = {}
+    for key, value in params.items():
+        sql = sql.replace(f":{key};", str(value))
 
     cache_info: _CacheInfo = _check_for_cached_results(
         sql=sql,

--- a/tests/test_athena.py
+++ b/tests/test_athena.py
@@ -151,7 +151,7 @@ def test_athena(path, glue_database, glue_table, kms_key, workgroup0, workgroup1
         ctas_approach=False,
         workgroup=workgroup1,
         keep_files=False,
-        params={"iint8_value": 1}
+        params={"iint8_value": 1},
     )
     assert len(df.index) == 1
     ensure_athena_query_metadata(df=df, ctas_approach=False, encrypted=False)

--- a/tests/test_athena.py
+++ b/tests/test_athena.py
@@ -145,6 +145,16 @@ def test_athena(path, glue_database, glue_table, kms_key, workgroup0, workgroup1
         wr.catalog.table(database=glue_database, table=table).to_dict()
         == wr.athena.describe_table(database=glue_database, table=table).to_dict()
     )
+    df = wr.athena.read_sql_query(
+        sql=f"SELECT * FROM {table} WHERE iint8 = :iint8_value;",
+        database=glue_database,
+        ctas_approach=False,
+        workgroup=workgroup1,
+        keep_files=False,
+        params={"iint8_value": 1}
+    )
+    assert len(df.index) == 1
+    ensure_athena_query_metadata(df=df, ctas_approach=False, encrypted=False)
     query = wr.athena.show_create_table(database=glue_database, table=table)
     assert (
         query.split("LOCATION")[0] == f"CREATE EXTERNAL TABLE `{table}`"


### PR DESCRIPTION
*Issue #432:*

*Description of changes:*
Add possibility to use `params` keyword for formatting the sql query which is ran against Athena. Only named parameters in the form `:name;` are accepted.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
