### PR TITLE
Hotfix: Fix packages in setup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import os
 from io import open
 from typing import Dict
 
-from setuptools import setup
+from setuptools import find_packages, setup
 
 here = os.path.abspath(os.path.dirname(__file__))
 about: Dict[str, str] = {}
@@ -22,14 +22,7 @@ setup(
     long_description=long_description,
     long_description_content_type="text/markdown",
     license=about["__license__"],
-    packages=[
-        "awswrangler",
-        "awswrangler.s3",
-        "awswrangler.catalog",
-        "awswrangler.quicksight",
-        "awswrangler.athena",
-        "awswrangler.catalog",
-    ],
+    packages=find_packages(exclude=["tests"]),
     include_package_data=True,
     python_requires=">=3.6, <3.9",
     install_requires=open("requirements.txt").read().strip().split("\n"),


### PR DESCRIPTION
*Description of changes:*
I forgot to add `awswrangler.dynamodb` to the `packages` list in `setup.py`. In order to prevent this from happening again use `find_packages()` instead of handling it manually.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
