### PR TITLE
Fix broken hyperlink in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Powered By [<img src="https://arrow.apache.org/img/arrow.png" width="200">](http
 - [Community Resources](#community-resources)
 - [Logging](#logging)
 - [Who uses AWS Data Wrangler?](#who-uses-aws-data-wrangler)
-- [What is Amazon SageMaker Data Wrangler?](#amazon-sageMaker-data-wrangler)
+- [What is Amazon SageMaker Data Wrangler?](#what-is-amazon-sageMaker-data-wrangler)
 
 ## Quick Start
 


### PR DESCRIPTION
**Issue #, if available:**

None

**Description of changes:**

Fixes a hyperlink for "What is Amazon SageMaker Data Wrangler?"

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
