### PR TITLE
Add botocore Config to wr.config

### DIFF
--- a/awswrangler/_config.py
+++ b/awswrangler/_config.py
@@ -5,7 +5,7 @@ import logging
 import os
 from typing import Any, Callable, Dict, List, NamedTuple, Optional, Tuple, Type, Union, cast
 
-import botocore
+import botocore.config
 import pandas as pd
 
 from awswrangler import exceptions

--- a/awswrangler/_config.py
+++ b/awswrangler/_config.py
@@ -5,6 +5,7 @@ import logging
 import os
 from typing import Any, Callable, Dict, List, NamedTuple, Optional, Tuple, Type, Union, cast
 
+import botocore
 import pandas as pd
 
 from awswrangler import exceptions
@@ -12,11 +13,11 @@ from awswrangler import exceptions
 _logger: logging.Logger = logging.getLogger(__name__)
 
 
-_ConfigValueType = Union[str, bool, int, None]
+_ConfigValueType = Union[str, bool, int, botocore.config.Config, None]
 
 
 class _ConfigArg(NamedTuple):
-    dtype: Type[Union[str, bool, int]]
+    dtype: Type[Union[str, bool, int, botocore.config.Config]]
     nullable: bool
     enforced: bool = False
 
@@ -41,6 +42,8 @@ _CONFIG_ARGS: Dict[str, _ConfigArg] = {
     "redshift_endpoint_url": _ConfigArg(dtype=str, nullable=True, enforced=True),
     "kms_endpoint_url": _ConfigArg(dtype=str, nullable=True, enforced=True),
     "emr_endpoint_url": _ConfigArg(dtype=str, nullable=True, enforced=True),
+    # Botocore config
+    "botocore_config": _ConfigArg(dtype=botocore.config.Config, nullable=True),
 }
 
 
@@ -57,6 +60,7 @@ class _Config:  # pylint: disable=too-many-instance-attributes
         self.redshift_endpoint_url = None
         self.kms_endpoint_url = None
         self.emr_endpoint_url = None
+        self.botocore_config = None
         for name in _CONFIG_ARGS:
             self._load_config(name=name)
 
@@ -337,6 +341,15 @@ class _Config:  # pylint: disable=too-many-instance-attributes
     @emr_endpoint_url.setter
     def emr_endpoint_url(self, value: Optional[str]) -> None:
         self._set_config_value(key="emr_endpoint_url", value=value)
+
+    @property
+    def botocore_config(self) -> botocore.config.Config:
+        """Property botocore_config."""
+        return cast(Optional[botocore.config.Config], self["botocore_config"])
+
+    @botocore_config.setter
+    def botocore_config(self, value: Optional[botocore.config.Config]) -> None:
+        self._set_config_value(key="botocore_config", value=value)
 
 
 def _insert_str(text: str, token: str, insert: str) -> str:

--- a/awswrangler/_utils.py
+++ b/awswrangler/_utils.py
@@ -16,6 +16,7 @@ import numpy as np
 import pandas as pd
 
 from awswrangler import _config, exceptions
+from awswrangler._config import apply_configs
 
 _logger: logging.Logger = logging.getLogger(__name__)
 
@@ -59,7 +60,7 @@ def boto3_from_primitives(primitives: Optional[Boto3PrimitivesType] = None) -> b
     return boto3.Session(**args)
 
 
-def botocore_config() -> botocore.config.Config:
+def default_botocore_config() -> botocore.config.Config:
     """Botocore configuration."""
     return botocore.config.Config(retries={"max_attempts": 5}, connect_timeout=10, max_pool_connections=10)
 
@@ -83,8 +84,9 @@ def _get_endpoint_url(service_name: str) -> Optional[str]:
     return endpoint_url
 
 
+@apply_configs
 def client(
-    service_name: str, session: Optional[boto3.Session] = None, config: Optional[botocore.config.Config] = None
+    service_name: str, session: Optional[boto3.Session] = None, botocore_config: Optional[botocore.config.Config] = None
 ) -> boto3.client:
     """Create a valid boto3.client."""
     endpoint_url: Optional[str] = _get_endpoint_url(service_name=service_name)
@@ -92,15 +94,21 @@ def client(
         service_name=service_name,
         endpoint_url=endpoint_url,
         use_ssl=True,
-        config=botocore_config() if config is None else config,
+        config=default_botocore_config() if botocore_config is None else botocore_config,
     )
 
 
-def resource(service_name: str, session: Optional[boto3.Session] = None) -> boto3.resource:
+@apply_configs
+def resource(
+    service_name: str, session: Optional[boto3.Session] = None, botocore_config: Optional[botocore.config.Config] = None
+) -> boto3.resource:
     """Create a valid boto3.resource."""
     endpoint_url: Optional[str] = _get_endpoint_url(service_name=service_name)
     return ensure_session(session=session).resource(
-        service_name=service_name, endpoint_url=endpoint_url, use_ssl=True, config=botocore_config()
+        service_name=service_name,
+        endpoint_url=endpoint_url,
+        use_ssl=True,
+        config=default_botocore_config() if botocore_config is None else botocore_config,
     )
 
 

--- a/awswrangler/_utils.py
+++ b/awswrangler/_utils.py
@@ -62,7 +62,11 @@ def boto3_from_primitives(primitives: Optional[Boto3PrimitivesType] = None) -> b
 
 def default_botocore_config() -> botocore.config.Config:
     """Botocore configuration."""
-    return botocore.config.Config(retries={"max_attempts": 5}, connect_timeout=10, max_pool_connections=10)
+    retries_config: Dict[str, Union[str, int]] = {"max_attempts": int(os.getenv("AWS_MAX_ATTEMPTS", "5"))}
+    retry_mode: Optional[str] = os.getenv("AWS_RETRY_MODE")
+    if retry_mode is not None:
+        retries_config["mode"] = retry_mode
+    return botocore.config.Config(retries=retries_config, connect_timeout=10, max_pool_connections=10)
 
 
 def _get_endpoint_url(service_name: str) -> Optional[str]:

--- a/awswrangler/_utils.py
+++ b/awswrangler/_utils.py
@@ -62,10 +62,10 @@ def boto3_from_primitives(primitives: Optional[Boto3PrimitivesType] = None) -> b
 
 def default_botocore_config() -> botocore.config.Config:
     """Botocore configuration."""
-    retries_config: Dict[str, Union[str, int]] = {"max_attempts": int(os.getenv("AWS_MAX_ATTEMPTS", "5"))}
-    retry_mode: Optional[str] = os.getenv("AWS_RETRY_MODE")
-    if retry_mode is not None:
-        retries_config["mode"] = retry_mode
+    retries_config: Dict[str, Union[str, int]] = {
+        "max_attempts": int(os.getenv("AWS_MAX_ATTEMPTS", "3")),
+        "mode": os.getenv("AWS_RETRY_MODE", "standard"),
+    }
     return botocore.config.Config(retries=retries_config, connect_timeout=10, max_pool_connections=10)
 
 

--- a/awswrangler/timestream.py
+++ b/awswrangler/timestream.py
@@ -39,7 +39,7 @@ def _write_batch(
     client: boto3.client = _utils.client(
         service_name="timestream-write",
         session=boto3_session,
-        config=Config(read_timeout=20, max_pool_connections=5000, retries={"max_attempts": 10}),
+        botocore_config=Config(read_timeout=20, max_pool_connections=5000, retries={"max_attempts": 10}),
     )
     try:
         _utils.try_it(
@@ -218,7 +218,7 @@ def query(sql: str, boto3_session: Optional[boto3.Session] = None) -> pd.DataFra
     client: boto3.client = _utils.client(
         service_name="timestream-query",
         session=boto3_session,
-        config=Config(read_timeout=60, retries={"max_attempts": 10}),
+        botocore_config=Config(read_timeout=60, retries={"max_attempts": 10}),
     )
     paginator = client.get_paginator("query")
     rows: List[List[Any]] = []

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -121,3 +121,41 @@ def test_basics(path, glue_database, glue_table, workgroup0, workgroup1):
 def test_athena_cache_configuration():
     wr.config.max_local_cache_entries = 20
     assert wr.config.max_remote_cache_entries == 20
+
+
+def test_botocore_config(path):
+    original = botocore.client.ClientCreator.create_client
+
+    # Default values for botocore.config.Config
+    expected_max_retries_attempt = 5
+    expected_connect_timeout = 10
+    expected_max_pool_connections = 10
+
+    def wrapper(self, **kwarg):
+        assert kwarg["client_config"].retries["max_attempts"] == expected_max_retries_attempt
+        assert kwarg["client_config"].connect_timeout == expected_connect_timeout
+        assert kwarg["client_config"].max_pool_connections == expected_max_pool_connections
+        return original(self, **kwarg)
+
+    # Check for default values
+    with patch("botocore.client.ClientCreator.create_client", new=wrapper):
+        with open_s3_object(path, mode="wb") as s3obj:
+            s3obj.write(b"foo")
+
+    # Update botocore.config.Config
+    expected_max_retries_attempt = 10
+    expected_connect_timeout = 20
+    expected_max_pool_connections = 30
+
+    botocore_config = botocore.config.Config(
+        retries={"max_attempts": expected_max_retries_attempt},
+        connect_timeout=expected_connect_timeout,
+        max_pool_connections=expected_max_pool_connections,
+    )
+    wr.config.botocore_config = botocore_config
+
+    with patch("botocore.client.ClientCreator.create_client", new=wrapper):
+        with open_s3_object(path, mode="wb") as s3obj:
+            s3obj.write(b"foo")
+
+    wr.config.reset()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -129,17 +129,16 @@ def test_botocore_config(path):
     original = botocore.client.ClientCreator.create_client
 
     # Default values for botocore.config.Config
-    expected_max_retries_attempt = 5
+    expected_max_retries_attempt = 3
     expected_connect_timeout = 10
     expected_max_pool_connections = 10
-    expected_retry_mode = ""
+    expected_retry_mode = "standard"
 
     def wrapper(self, **kwarg):
         assert kwarg["client_config"].retries["max_attempts"] == expected_max_retries_attempt
         assert kwarg["client_config"].connect_timeout == expected_connect_timeout
         assert kwarg["client_config"].max_pool_connections == expected_max_pool_connections
-        if expected_retry_mode:
-            assert kwarg["client_config"].retries["mode"] == expected_retry_mode
+        assert kwarg["client_config"].retries["mode"] == expected_retry_mode
         return original(self, **kwarg)
 
     # Check for default values
@@ -151,7 +150,7 @@ def test_botocore_config(path):
     expected_max_retries_attempt = 20
     expected_connect_timeout = 10
     expected_max_pool_connections = 10
-    expected_retry_mode = "standard"
+    expected_retry_mode = "adaptive"
 
     os.environ["AWS_MAX_ATTEMPTS"] = str(expected_max_retries_attempt)
     os.environ["AWS_RETRY_MODE"] = expected_retry_mode
@@ -167,10 +166,10 @@ def test_botocore_config(path):
     expected_max_retries_attempt = 30
     expected_connect_timeout = 40
     expected_max_pool_connections = 50
-    expected_retry_mode = ""
+    expected_retry_mode = "legacy"
 
     botocore_config = botocore.config.Config(
-        retries={"max_attempts": expected_max_retries_attempt},
+        retries={"max_attempts": expected_max_retries_attempt, "mode": expected_retry_mode},
         connect_timeout=expected_connect_timeout,
         max_pool_connections=expected_max_pool_connections,
     )

--- a/tutorials/021 - Global Configurations.ipynb
+++ b/tutorials/021 - Global Configurations.ipynb
@@ -17,7 +17,9 @@
     "\n",
     "*P.P.S. One exception to the above mentioned rules is the `botocore_config` property. It cannot be set through environment variables\n",
     "but only via `wr.config`. It will be used as the `botocore.config.Config` for all underlying `boto3` calls.\n",
-    "The default config is `botocore.config.Config(retries={\"max_attempts\": 5}, connect_timeout=10, max_pool_connections=10)`*"
+    "The default config is `botocore.config.Config(retries={\"max_attempts\": 5}, connect_timeout=10, max_pool_connections=10)`.\n",
+    "If you only want to change the retry behavior, you can use the environment variables `AWS_MAX_ATTEMPTS` and `AWS_RETRY_MODE`.\n",
+    "(see [Boto3 documentation](https://boto3.amazonaws.com/v1/documentation/api/latest/guide/configuration.html#using-environment-variables))*"
    ]
   },
   {

--- a/tutorials/021 - Global Configurations.ipynb
+++ b/tutorials/021 - Global Configurations.ipynb
@@ -13,7 +13,11 @@
     "- **Environment variables**\n",
     "- **wr.config**\n",
     "\n",
-    "*P.S. Check the [function API doc](https://aws-data-wrangler.readthedocs.io/en/stable/api.html) to see if your function has some argument that can be configured through Global configurations.*"
+    "*P.S. Check the [function API doc](https://aws-data-wrangler.readthedocs.io/en/stable/api.html) to see if your function has some argument that can be configured through Global configurations.*\n",
+    "\n",
+    "*P.P.S. One exception to the above mentioned rules is the `botocore_config` property. It cannot be set through environment variables\n",
+    "but only via `wr.config`. It will be used as the `botocore.config.Config` for all underlying `boto3` calls.\n",
+    "The default config is `botocore.config.Config(retries={\"max_attempts\": 5}, connect_timeout=10, max_pool_connections=10)`*"
    ]
   },
   {
@@ -56,7 +60,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import awswrangler as wr"
+    "import awswrangler as wr\n",
+    "import botocore"
    ]
   },
   {
@@ -66,8 +71,8 @@
    "outputs": [
     {
      "data": {
-      "text/plain": "   FOO\n0    1",
-      "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>FOO</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>1</td>\n    </tr>\n  </tbody>\n</table>\n</div>"
+      "text/plain": "   foo\n0    1",
+      "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>foo</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>1</td>\n    </tr>\n  </tbody>\n</table>\n</div>"
      },
      "execution_count": 3,
      "metadata": {},
@@ -115,7 +120,13 @@
     "wr.config.max_cache_seconds = 900\n",
     "wr.config.max_cache_query_inspections = 500\n",
     "wr.config.max_remote_cache_entries = 50\n",
-    "wr.config.max_local_cache_entries = 100"
+    "wr.config.max_local_cache_entries = 100\n",
+    "# Set botocore.config.Config that will be used for all boto3 calls\n",
+    "wr.config.botocore_config = botocore.config.Config(\n",
+    "    retries={\"max_attempts\": 10},\n",
+    "    connect_timeout=20,\n",
+    "    max_pool_connections=20\n",
+    ")"
    ]
   },
   {
@@ -125,8 +136,8 @@
    "outputs": [
     {
      "data": {
-      "text/plain": "   FOO\n0    1",
-      "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>FOO</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>1</td>\n    </tr>\n  </tbody>\n</table>\n</div>"
+      "text/plain": "   foo\n0    1",
+      "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>foo</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>1</td>\n    </tr>\n  </tbody>\n</table>\n</div>"
      },
      "execution_count": 6,
      "metadata": {},
@@ -151,8 +162,8 @@
    "outputs": [
     {
      "data": {
-      "text/plain": "<awswrangler._config._Config at 0x1e0313cb5e0>",
-      "text/html": "<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>name</th>\n      <th>Env. Variable</th>\n      <th>type</th>\n      <th>nullable</th>\n      <th>enforced</th>\n      <th>configured</th>\n      <th>value</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>catalog_id</td>\n      <td>WR_CATALOG_ID</td>\n      <td>&lt;class 'str'&gt;</td>\n      <td>True</td>\n      <td>False</td>\n      <td>False</td>\n      <td>None</td>\n    </tr>\n    <tr>\n      <th>1</th>\n      <td>concurrent_partitioning</td>\n      <td>WR_CONCURRENT_PARTITIONING</td>\n      <td>&lt;class 'bool'&gt;</td>\n      <td>False</td>\n      <td>False</td>\n      <td>False</td>\n      <td>None</td>\n    </tr>\n    <tr>\n      <th>2</th>\n      <td>ctas_approach</td>\n      <td>WR_CTAS_APPROACH</td>\n      <td>&lt;class 'bool'&gt;</td>\n      <td>False</td>\n      <td>False</td>\n      <td>True</td>\n      <td>False</td>\n    </tr>\n    <tr>\n      <th>3</th>\n      <td>database</td>\n      <td>WR_DATABASE</td>\n      <td>&lt;class 'str'&gt;</td>\n      <td>True</td>\n      <td>False</td>\n      <td>True</td>\n      <td>default</td>\n    </tr>\n    <tr>\n      <th>4</th>\n      <td>max_cache_query_inspections</td>\n      <td>WR_MAX_CACHE_QUERY_INSPECTIONS</td>\n      <td>&lt;class 'int'&gt;</td>\n      <td>False</td>\n      <td>False</td>\n      <td>True</td>\n      <td>500</td>\n    </tr>\n    <tr>\n      <th>5</th>\n      <td>max_cache_seconds</td>\n      <td>WR_MAX_CACHE_SECONDS</td>\n      <td>&lt;class 'int'&gt;</td>\n      <td>False</td>\n      <td>False</td>\n      <td>True</td>\n      <td>900</td>\n    </tr>\n    <tr>\n      <th>6</th>\n      <td>max_remote_cache_entries</td>\n      <td>WR_MAX_REMOTE_CACHE_ENTRIES</td>\n      <td>&lt;class 'int'&gt;</td>\n      <td>False</td>\n      <td>False</td>\n      <td>True</td>\n      <td>50</td>\n    </tr>\n    <tr>\n      <th>7</th>\n      <td>max_local_cache_entries</td>\n      <td>WR_MAX_LOCAL_CACHE_ENTRIES</td>\n      <td>&lt;class 'int'&gt;</td>\n      <td>False</td>\n      <td>False</td>\n      <td>True</td>\n      <td>100</td>\n    </tr>\n    <tr>\n      <th>8</th>\n      <td>s3_block_size</td>\n      <td>WR_S3_BLOCK_SIZE</td>\n      <td>&lt;class 'int'&gt;</td>\n      <td>False</td>\n      <td>True</td>\n      <td>False</td>\n      <td>None</td>\n    </tr>\n    <tr>\n      <th>9</th>\n      <td>workgroup</td>\n      <td>WR_WORKGROUP</td>\n      <td>&lt;class 'str'&gt;</td>\n      <td>False</td>\n      <td>True</td>\n      <td>False</td>\n      <td>None</td>\n    </tr>\n    <tr>\n      <th>10</th>\n      <td>s3_endpoint_url</td>\n      <td>WR_S3_ENDPOINT_URL</td>\n      <td>&lt;class 'str'&gt;</td>\n      <td>True</td>\n      <td>True</td>\n      <td>True</td>\n      <td>None</td>\n    </tr>\n    <tr>\n      <th>11</th>\n      <td>athena_endpoint_url</td>\n      <td>WR_ATHENA_ENDPOINT_URL</td>\n      <td>&lt;class 'str'&gt;</td>\n      <td>True</td>\n      <td>True</td>\n      <td>True</td>\n      <td>None</td>\n    </tr>\n    <tr>\n      <th>12</th>\n      <td>sts_endpoint_url</td>\n      <td>WR_STS_ENDPOINT_URL</td>\n      <td>&lt;class 'str'&gt;</td>\n      <td>True</td>\n      <td>True</td>\n      <td>True</td>\n      <td>None</td>\n    </tr>\n    <tr>\n      <th>13</th>\n      <td>glue_endpoint_url</td>\n      <td>WR_GLUE_ENDPOINT_URL</td>\n      <td>&lt;class 'str'&gt;</td>\n      <td>True</td>\n      <td>True</td>\n      <td>True</td>\n      <td>None</td>\n    </tr>\n    <tr>\n      <th>14</th>\n      <td>redshift_endpoint_url</td>\n      <td>WR_REDSHIFT_ENDPOINT_URL</td>\n      <td>&lt;class 'str'&gt;</td>\n      <td>True</td>\n      <td>True</td>\n      <td>True</td>\n      <td>None</td>\n    </tr>\n    <tr>\n      <th>15</th>\n      <td>kms_endpoint_url</td>\n      <td>WR_KMS_ENDPOINT_URL</td>\n      <td>&lt;class 'str'&gt;</td>\n      <td>True</td>\n      <td>True</td>\n      <td>True</td>\n      <td>None</td>\n    </tr>\n    <tr>\n      <th>16</th>\n      <td>emr_endpoint_url</td>\n      <td>WR_EMR_ENDPOINT_URL</td>\n      <td>&lt;class 'str'&gt;</td>\n      <td>True</td>\n      <td>True</td>\n      <td>True</td>\n      <td>None</td>\n    </tr>\n  </tbody>\n</table>"
+      "text/plain": "<awswrangler._config._Config at 0x2d3a2c63df0>",
+      "text/html": "<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>name</th>\n      <th>Env. Variable</th>\n      <th>type</th>\n      <th>nullable</th>\n      <th>enforced</th>\n      <th>configured</th>\n      <th>value</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>catalog_id</td>\n      <td>WR_CATALOG_ID</td>\n      <td>&lt;class 'str'&gt;</td>\n      <td>True</td>\n      <td>False</td>\n      <td>False</td>\n      <td>None</td>\n    </tr>\n    <tr>\n      <th>1</th>\n      <td>concurrent_partitioning</td>\n      <td>WR_CONCURRENT_PARTITIONING</td>\n      <td>&lt;class 'bool'&gt;</td>\n      <td>False</td>\n      <td>False</td>\n      <td>False</td>\n      <td>None</td>\n    </tr>\n    <tr>\n      <th>2</th>\n      <td>ctas_approach</td>\n      <td>WR_CTAS_APPROACH</td>\n      <td>&lt;class 'bool'&gt;</td>\n      <td>False</td>\n      <td>False</td>\n      <td>True</td>\n      <td>False</td>\n    </tr>\n    <tr>\n      <th>3</th>\n      <td>database</td>\n      <td>WR_DATABASE</td>\n      <td>&lt;class 'str'&gt;</td>\n      <td>True</td>\n      <td>False</td>\n      <td>True</td>\n      <td>default</td>\n    </tr>\n    <tr>\n      <th>4</th>\n      <td>max_cache_query_inspections</td>\n      <td>WR_MAX_CACHE_QUERY_INSPECTIONS</td>\n      <td>&lt;class 'int'&gt;</td>\n      <td>False</td>\n      <td>False</td>\n      <td>True</td>\n      <td>500</td>\n    </tr>\n    <tr>\n      <th>5</th>\n      <td>max_cache_seconds</td>\n      <td>WR_MAX_CACHE_SECONDS</td>\n      <td>&lt;class 'int'&gt;</td>\n      <td>False</td>\n      <td>False</td>\n      <td>True</td>\n      <td>900</td>\n    </tr>\n    <tr>\n      <th>6</th>\n      <td>max_remote_cache_entries</td>\n      <td>WR_MAX_REMOTE_CACHE_ENTRIES</td>\n      <td>&lt;class 'int'&gt;</td>\n      <td>False</td>\n      <td>False</td>\n      <td>True</td>\n      <td>50</td>\n    </tr>\n    <tr>\n      <th>7</th>\n      <td>max_local_cache_entries</td>\n      <td>WR_MAX_LOCAL_CACHE_ENTRIES</td>\n      <td>&lt;class 'int'&gt;</td>\n      <td>False</td>\n      <td>False</td>\n      <td>True</td>\n      <td>100</td>\n    </tr>\n    <tr>\n      <th>8</th>\n      <td>s3_block_size</td>\n      <td>WR_S3_BLOCK_SIZE</td>\n      <td>&lt;class 'int'&gt;</td>\n      <td>False</td>\n      <td>True</td>\n      <td>False</td>\n      <td>None</td>\n    </tr>\n    <tr>\n      <th>9</th>\n      <td>workgroup</td>\n      <td>WR_WORKGROUP</td>\n      <td>&lt;class 'str'&gt;</td>\n      <td>False</td>\n      <td>True</td>\n      <td>False</td>\n      <td>None</td>\n    </tr>\n    <tr>\n      <th>10</th>\n      <td>s3_endpoint_url</td>\n      <td>WR_S3_ENDPOINT_URL</td>\n      <td>&lt;class 'str'&gt;</td>\n      <td>True</td>\n      <td>True</td>\n      <td>True</td>\n      <td>None</td>\n    </tr>\n    <tr>\n      <th>11</th>\n      <td>athena_endpoint_url</td>\n      <td>WR_ATHENA_ENDPOINT_URL</td>\n      <td>&lt;class 'str'&gt;</td>\n      <td>True</td>\n      <td>True</td>\n      <td>True</td>\n      <td>None</td>\n    </tr>\n    <tr>\n      <th>12</th>\n      <td>sts_endpoint_url</td>\n      <td>WR_STS_ENDPOINT_URL</td>\n      <td>&lt;class 'str'&gt;</td>\n      <td>True</td>\n      <td>True</td>\n      <td>True</td>\n      <td>None</td>\n    </tr>\n    <tr>\n      <th>13</th>\n      <td>glue_endpoint_url</td>\n      <td>WR_GLUE_ENDPOINT_URL</td>\n      <td>&lt;class 'str'&gt;</td>\n      <td>True</td>\n      <td>True</td>\n      <td>True</td>\n      <td>None</td>\n    </tr>\n    <tr>\n      <th>14</th>\n      <td>redshift_endpoint_url</td>\n      <td>WR_REDSHIFT_ENDPOINT_URL</td>\n      <td>&lt;class 'str'&gt;</td>\n      <td>True</td>\n      <td>True</td>\n      <td>True</td>\n      <td>None</td>\n    </tr>\n    <tr>\n      <th>15</th>\n      <td>kms_endpoint_url</td>\n      <td>WR_KMS_ENDPOINT_URL</td>\n      <td>&lt;class 'str'&gt;</td>\n      <td>True</td>\n      <td>True</td>\n      <td>True</td>\n      <td>None</td>\n    </tr>\n    <tr>\n      <th>16</th>\n      <td>emr_endpoint_url</td>\n      <td>WR_EMR_ENDPOINT_URL</td>\n      <td>&lt;class 'str'&gt;</td>\n      <td>True</td>\n      <td>True</td>\n      <td>True</td>\n      <td>None</td>\n    </tr>\n    <tr>\n      <th>17</th>\n      <td>botocore_config</td>\n      <td>WR_BOTOCORE_CONFIG</td>\n      <td>&lt;class 'botocore.config.Config'&gt;</td>\n      <td>True</td>\n      <td>False</td>\n      <td>True</td>\n      <td>&lt;botocore.config.Config object at 0x000002D3A362E760&gt;</td>\n    </tr>\n  </tbody>\n</table>"
      },
      "execution_count": 7,
      "metadata": {},


### PR DESCRIPTION
*Issue #532:*

*Description of changes:*
Adding the property `botocore_config` to `awsrangler.config` and using it for all `boto3` clients and resources if it is set.

However this change has some drawbacks:

1. Not all config properties are simple datatypes anymore and `botocore_config` cannot be set via environment variables.
2. The functionality is a little bit hidden, as it does not show up in the documentation itself but only in the configuration tutorial.

@igorborgest What do you think about this?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
