### PR TITLE
fix: remove strict requirement of s3:// path

### DIFF
--- a/awswrangler/_utils.py
+++ b/awswrangler/_utils.py
@@ -141,8 +141,6 @@ def parse_path(path: str) -> Tuple[str, str]:
     >>> from awswrangler._utils import parse_path
     >>> bucket, key = parse_path('s3://arn:aws:s3:<awsregion>:<awsaccount>:accesspoint/<ap_name>/<key>')
     """
-    if path.startswith("s3://") is False:
-        raise exceptions.InvalidArgumentValue(f"'{path}' is not a valid path. It MUST start with 's3://'")
     parts = path.replace("s3://", "").replace(":accesspoint/", ":accesspoint:").split("/", 1)
     bucket: str = parts[0]
     if "/" in bucket:


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/awslabs/aws-data-wrangler/issues/558

*Description of changes:*
I've removed the strict requirement that the path begins with `s3://` in the `parse_path` utility.

This means that tools like [Localstack](https://github.com/localstack/localstack) can be used to mock functionality locally or in CI.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
