### PR TITLE
timezone should be applied before index is set

### DIFF
--- a/awswrangler/s3/_read_parquet.py
+++ b/awswrangler/s3/_read_parquet.py
@@ -266,8 +266,8 @@ def _arrowtable2df(
     df = _utils.ensure_df_is_mutable(df=df)
     if metadata:
         _logger.debug("metadata: %s", metadata)
-        df = _apply_index(df=df, metadata=metadata)
         df = _apply_timezone(df=df, metadata=metadata)
+        df = _apply_index(df=df, metadata=metadata)
     return df
 
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
_read_parquet fails for a df which has a tz-aware column in the index. It drops tz information, because columns are moved (by _apply_index) to the index before tz information is applied to the remaining columns.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
