### PR TITLE
Bump2version setup

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,0 +1,39 @@
+[bumpversion]
+current_version = 2.4.0
+commit = True
+tag = True
+tag_name = {new_version}
+
+[bumpversion:file:README.md]
+
+[bumpversion:file:CONTRIBUTING_COMMON_ERRORS.md]
+
+[bumpversion:file:tests/test_metadata.py]
+
+[bumpversion:file:docs/source/install.rst]
+
+[bumpversion:file:docs/source/what.rst]
+
+[bumpversion:file:awswrangler/__metadata__.py]
+
+[bumpversion:file:awswrangler/athena/_read.py]
+
+[bumpversion:file:awswrangler/s3/_read_parquet.py]
+
+[bumpversion:file:awswrangler/s3/_read_text.py]
+
+[bumpversion:file:awswrangler/s3/_write_parquet.py]
+
+[bumpversion:file:awswrangler/s3/_write_text.py]
+
+[bumpversion:file:tutorials/001 - Introduction.ipynb]
+
+[bumpversion:file:tutorials/007 - Redshift, MySQL, PostgreSQL, SQL Server.ipynb]
+
+[bumpversion:file:tutorials/014 - Schema Evolution.ipynb]
+
+[bumpversion:file:tutorials/021 - Global Configurations.ipynb]
+
+[bumpversion:file:tutorials/022 - Writing Partitions Concurrently.ipynb]
+
+[bumpversion:file:tutorials/023 - Flexible Partitions Filter.ipynb]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -246,3 +246,10 @@ or
 
 Check the file below to check the common errors and solutions
 [ERRORS](https://github.com/awslabs/aws-data-wrangler/blob/main/CONTRIBUTING_COMMON_ERRORS.md)
+
+## Bumping version
+When there is a new release you can use `bump2version` for updating the version number in relevant files.
+You can run `bump2version major|minor|patch` in the top directory and the following steps will be executed:
+- The version number in all files which are listed in `.bumpversion.cfg` is updated
+- A new commit with message `Bump version: {current_version} → {new_version}` is created
+- A new Git tag `{new_version}` is created

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -24,4 +24,5 @@ moto==2.0.0
 jupyterlab==3.0.9
 s3fs==0.4.2
 python-Levenshtein==0.12.2
+bump2version==1.0.1
 -e .[sqlserver]


### PR DESCRIPTION
*Issue #573:*

*Description of changes:*
Adding `bump2version` for updating the version number in relevant files.
Usage: `bump2version major|minor|patch` and it will update the version number in all files given in `.bumpversion.cfg`, creates a commit with message `Bump version: {current_version} → {new_version}` and creates a tag with `{new_version}`.

A short How-To is also added to `CONTRIBUTING.md`.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
