### PR TITLE
Bumping pg8000 version to 1.19

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,5 @@ pandas>=1.1.0,<1.3.0
 pyarrow>=2.0.0,<3.1.0
 redshift-connector~=2.0.0
 pymysql>=0.9.0,<1.1.0
-pg8000>=1.16.0,<1.18.0
+pg8000>=1.16.0,<1.19.0
 openpyxl~=3.0.0


### PR DESCRIPTION
Bumping pg8000 version:
1.18 -> 1.19

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
