### PR TITLE
Adding ctas_database_name argument

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -171,6 +171,16 @@ def redshift_external_schema(cloudformation_outputs, databases_parameters, glue_
 
 
 @pytest.fixture(scope="function")
+def glue_ctas_database():
+    name = f"db_{get_time_str_with_random_suffix()}"
+    print(f"Database name: {name}")
+    wr.catalog.create_database(name=name)
+    yield name
+    wr.catalog.delete_database(name=name)
+    print(f"Database {name} deleted.")
+
+
+@pytest.fixture(scope="function")
 def glue_table(glue_database: str) -> None:
     name = f"tbl_{get_time_str_with_random_suffix()}"
     print(f"Table name: {name}")


### PR DESCRIPTION
*Issue #, if available:*
#576

*Description of changes:*
- Added optional `ctas_database_name` argument to store `ctas_temporary_table` in an alternative database (i.e. not the context database)
- This alternative database must exist and won't be created
- Added additional test in `test_athena_ctas`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
