### PR TITLE
Major - Make path argument in wr.s3.to functions optional

### DIFF
--- a/awswrangler/s3/_write.py
+++ b/awswrangler/s3/_write.py
@@ -47,7 +47,7 @@ def _validate_args(
     table: Optional[str],
     database: Optional[str],
     dataset: bool,
-    path: str,
+    path: Optional[str],
     partition_cols: Optional[List[str]],
     bucketing_info: Optional[Tuple[List[str], int]],
     mode: Optional[str],
@@ -58,6 +58,8 @@ def _validate_args(
     if df.empty is True:
         raise exceptions.EmptyDataFrame()
     if dataset is False:
+        if path is None:
+            raise exceptions.InvalidArgumentValue("If dataset is False, the `path` argument must be passed.")
         if path.endswith("/"):
             raise exceptions.InvalidArgumentValue(
                 "If <dataset=False>, the argument <path> should be a file path, not a directory."
@@ -78,6 +80,10 @@ def _validate_args(
         raise exceptions.InvalidArgumentCombination(
             "Arguments database and table must be passed together. If you want to store your dataset metadata in "
             "the Glue Catalog, please ensure you are passing both."
+        )
+    elif all(x is None for x in [path, database, table]):
+        raise exceptions.InvalidArgumentCombination(
+            "You must specify a `path` if dataset is True and database/table are not enabled."
         )
     elif bucketing_info and bucketing_info[1] <= 0:
         raise exceptions.InvalidArgumentValue(

--- a/tests/test__routines.py
+++ b/tests/test__routines.py
@@ -44,7 +44,6 @@ def test_routine_0(glue_database, glue_table, path, use_threads, concurrent_part
     df = pd.DataFrame({"c1": [None, 1, None]}, dtype="Int16")
     wr.s3.to_parquet(
         df=df,
-        path=path,
         dataset=True,
         mode="overwrite",
         database=glue_database,
@@ -101,7 +100,6 @@ def test_routine_0(glue_database, glue_table, path, use_threads, concurrent_part
     df = pd.DataFrame({"c2": ["a", None, "b"], "c1": [None, None, None]})
     wr.s3.to_parquet(
         df=df,
-        path=path,
         dataset=True,
         mode="append",
         database=glue_database,
@@ -162,7 +160,6 @@ def test_routine_0(glue_database, glue_table, path, use_threads, concurrent_part
     df = pd.DataFrame({"c0": ["foo", None], "c1": [0, 1]})
     wr.s3.to_parquet(
         df=df,
-        path=path,
         dataset=True,
         mode="overwrite",
         database=glue_database,
@@ -223,7 +220,6 @@ def test_routine_0(glue_database, glue_table, path, use_threads, concurrent_part
     df = pd.DataFrame({"c0": [1, 2], "c1": ["1", "3"], "c2": [True, False]})
     wr.s3.to_parquet(
         df=df,
-        path=path,
         dataset=True,
         mode="overwrite_partitions",
         database=glue_database,

--- a/tests/test_athena_csv.py
+++ b/tests/test_athena_csv.py
@@ -49,7 +49,6 @@ def test_to_csv_modes(glue_database, glue_table, path, use_threads, concurrent_p
     df = pd.DataFrame({"c1": [0, 1, 2]}, dtype="Int16")
     wr.s3.to_csv(
         df=df,
-        path=path,
         dataset=True,
         mode="overwrite",
         database=glue_database,
@@ -106,7 +105,6 @@ def test_to_csv_modes(glue_database, glue_table, path, use_threads, concurrent_p
     df = pd.DataFrame({"c0": ["foo", "boo"], "c1": [0, 1]})
     wr.s3.to_csv(
         df=df,
-        path=path,
         dataset=True,
         mode="overwrite",
         database=glue_database,

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -103,6 +103,23 @@ def test_delete_error(bucket):
             wr.s3.delete_objects(path=[path])
 
 
+def test_missing_or_wrong_path(path, glue_database, glue_table):
+    # Missing path
+    df = pd.DataFrame({"FooBoo": [1, 2, 3]})
+    with pytest.raises(wr.exceptions.InvalidArgumentValue):
+        wr.s3.to_parquet(df=df)
+    with pytest.raises(wr.exceptions.InvalidArgumentCombination):
+        wr.s3.to_parquet(df=df, dataset=True)
+    with pytest.raises(wr.exceptions.InvalidArgumentValue):
+        wr.s3.to_parquet(df=df, dataset=True, database=glue_database, table=glue_table)
+
+    # Wrong path
+    wr.s3.to_parquet(df=df, path=path, dataset=True, database=glue_database, table=glue_table)
+    wrong_path = "s3://bucket/prefix"
+    with pytest.raises(wr.exceptions.InvalidArgumentValue):
+        wr.s3.to_parquet(df=df, path=wrong_path, dataset=True, database=glue_database, table=glue_table)
+
+
 def test_s3_empty_dfs():
     df = pd.DataFrame()
     with pytest.raises(wr.exceptions.EmptyDataFrame):


### PR DESCRIPTION
*Issue #, if available:*
#586

*Description of changes:*
`path` argument is now optional. The code changes implementing this feature are based on the below logic tree:
```
if dataset is False:
	if path is None:
		raise Exception("you must pass `path`")
	else:
		no problem
else:
	if database and table are None:
		if path is None:
			raise Exception("you must pass `path`")
		else:
			no problem
	else:
		if path is None:
			if table exists:
				path = catalog_path
			else:
				raise Exception("you must pass `path`")
		else:
			if table exists:
				if path != catalog_path:
					raise Exception("`path` must be equal to catalog path")
			else:
				no problem
```

Added and modified `s3` tests to evaluate impact

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
