### PR TITLE
Mysql upsert

### DIFF
--- a/awswrangler/athena/_read.py
+++ b/awswrangler/athena/_read.py
@@ -751,7 +751,7 @@ def read_sql_query(
     params: Dict[str, any], optional
         Dict of parameters that will be used for constructing the SQL query. Only named parameters are supported.
         The dict needs to contain the information in the form {'name': 'value'} and the SQL query needs to contain
-        `:name;`.
+        `:name;`. Note that for varchar columns and similar, you must surround the value in single quotes.
     s3_additional_kwargs : Optional[Dict[str, Any]]
         Forward to botocore requests. Valid parameters: "RequestPayer", "ExpectedBucketOwner".
         e.g. s3_additional_kwargs={'RequestPayer': 'requester'}
@@ -769,8 +769,8 @@ def read_sql_query(
 
     >>> import awswrangler as wr
     >>> df = wr.athena.read_sql_query(
-    ...     sql="SELECT * FROM my_table WHERE name=:name;",
-    ...     params={"name": "filtered_name"}
+    ...     sql="SELECT * FROM my_table WHERE name=:name; AND city=:city;",
+    ...     params={"name": "'filtered_name'", "city": "'filtered_city'"}
     ... )
 
     """

--- a/awswrangler/mysql.py
+++ b/awswrangler/mysql.py
@@ -366,7 +366,7 @@ def to_sql(
             upsert_str = ""
             if use_column_names:
                 insertion_columns = f"({', '.join(df.columns)})"
-            if mode.lower().strip() == "upsert_duplicate_key":
+            if mode == "upsert_duplicate_key":
                 upsert_columns = ", ".join(df.columns.map(lambda column: f"`{column}`=VALUES(`{column}`)"))
                 upsert_str = f" ON DUPLICATE KEY UPDATE {upsert_columns}"
             placeholder_parameter_pair_generator = _db_utils.generate_placeholder_parameter_pairs(
@@ -374,14 +374,14 @@ def to_sql(
             )
             sql: str
             for placeholders, parameters in placeholder_parameter_pair_generator:
-                if mode.lower().strip() == "upsert_replace_into":
+                if mode == "upsert_replace_into":
                     sql = f"REPLACE INTO `{schema}`.`{table}` {insertion_columns} VALUES {placeholders}"
                 else:
                     sql = f"INSERT INTO `{schema}`.`{table}` {insertion_columns} VALUES {placeholders}{upsert_str}"
                 _logger.debug("sql: %s", sql)
                 cursor.executemany(sql, (parameters,))
             con.commit()
-            if mode.lower().strip() == "upsert_distinct":
+            if mode == "upsert_distinct":
                 temp_table = f"{table}_{uuid.uuid4().hex}"
                 cursor.execute(f"CREATE TABLE `{schema}`.`{temp_table}` LIKE `{schema}`.`{table}`")
                 cursor.execute(f"INSERT INTO `{schema}`.`{temp_table}` SELECT DISTINCT * FROM `{schema}`.`{table}`")

--- a/awswrangler/mysql.py
+++ b/awswrangler/mysql.py
@@ -1,6 +1,8 @@
 """Amazon MySQL Module."""
 
 import logging
+import random
+import string
 from typing import Any, Dict, Iterator, List, Optional, Tuple, Union
 
 import boto3
@@ -284,7 +286,16 @@ def to_sql(
     schema : str
         Schema name
     mode : str
-        Append or overwrite.
+        Append, overwrite, upsert_duplicate_key, upsert_replace_into, upsert_distinct.
+            append: Inserts new records into table
+            overwrite: Drops table and recreates
+            upsert_duplicate_key: Performs an upsert using `ON DUPLICATE KEY` clause. Requires table schema to have
+            defined keys, otherwise duplicate records will be inserted.
+            upsert_replace: Performs upsert using `REPLACE INTO` clause. Less efficient and still requires the table
+            schema to have keys or else duplicate records will be inserted upsert_distinct: Inserts new records,
+            including duplicates, then recreates the table and inserts `DISTINCT` records from old table. This is the
+            least efficient approach, but handles scenarios where there are no keys on table.
+
     index : bool
         True to store the DataFrame index as a column in the table,
         otherwise False to ignore it.
@@ -323,6 +334,16 @@ def to_sql(
     """
     if df.empty is True:
         raise exceptions.EmptyDataFrame()
+    if mode.strip().lower() not in [
+        "append",
+        "overwrite",
+        "upsert_replace_into",
+        "upsert_duplicate_key",
+        "upsert_distinct",
+    ]:
+        raise exceptions.InvalidArgumentValue(
+            "mode must be one of append, overwrite, upsert_replace_into, upsert_duplicate_key, upsert_distinct"
+        )
     _validate_connection(con=con)
     try:
         with con.cursor() as cursor:
@@ -340,16 +361,33 @@ def to_sql(
                 df.reset_index(level=df.index.names, inplace=True)
             column_placeholders: str = ", ".join(["%s"] * len(df.columns))
             insertion_columns = ""
+            upsert_columns = ""
+            upsert_str = ""
             if use_column_names:
                 insertion_columns = f"({', '.join(df.columns)})"
+            if mode.lower().strip() == "upsert_duplicate_key":
+                upsert_columns = ", ".join(df.columns.map(lambda column: f"`{column}`=VALUES(`{column}`)"))
+                upsert_str = f" ON DUPLICATE KEY UPDATE {upsert_columns}"
             placeholder_parameter_pair_generator = _db_utils.generate_placeholder_parameter_pairs(
                 df=df, column_placeholders=column_placeholders, chunksize=chunksize
             )
+            sql: str
             for placeholders, parameters in placeholder_parameter_pair_generator:
-                sql: str = f"INSERT INTO `{schema}`.`{table}` {insertion_columns} VALUES {placeholders}"
+                if mode.lower().strip() == "upsert_replace_into":
+                    sql = f"REPLACE INTO `{schema}`.`{table}` {insertion_columns} VALUES {placeholders}"
+                else:
+                    sql = f"INSERT INTO `{schema}`.`{table}` {insertion_columns} VALUES {placeholders}{upsert_str}"
                 _logger.debug("sql: %s", sql)
                 cursor.executemany(sql, (parameters,))
             con.commit()
+            if mode.lower().strip() == "upsert_distinct":
+                temp_table = f"{table}_{''.join(random.choice(string.ascii_lowercase) for i in range(10))}"
+                cursor.execute(f"CREATE TABLE `{schema}`.`{temp_table}` LIKE `{schema}`.`{table}`")
+                cursor.execute(f"INSERT INTO `{schema}`.`{temp_table}` SELECT DISTINCT * FROM `{schema}`.`{table}`")
+                cursor.execute(f"DROP TABLE IF EXISTS `{schema}`.`{table}`")
+                cursor.execute(f"ALTER TABLE `{schema}`.`{temp_table}` RENAME TO `{table}`")
+                con.commit()
+
     except Exception as ex:
         con.rollback()
         _logger.error(ex)

--- a/awswrangler/mysql.py
+++ b/awswrangler/mysql.py
@@ -291,8 +291,8 @@ def to_sql(
             overwrite: Drops table and recreates
             upsert_duplicate_key: Performs an upsert using `ON DUPLICATE KEY` clause. Requires table schema to have
             defined keys, otherwise duplicate records will be inserted.
-            upsert_replace: Performs upsert using `REPLACE INTO` clause. Less efficient and still requires the table
-            schema to have keys or else duplicate records will be inserted upsert_distinct: Inserts new records,
+            upsert_replace_into: Performs upsert using `REPLACE INTO` clause. Less efficient and still requires the
+            table schema to have keys or else duplicate records will be inserted upsert_distinct: Inserts new records,
             including duplicates, then recreates the table and inserts `DISTINCT` records from old table. This is the
             least efficient approach, but handles scenarios where there are no keys on table.
 

--- a/tests/test_mysql.py
+++ b/tests/test_mysql.py
@@ -200,6 +200,84 @@ def test_insert_with_column_names(mysql_table, mysql_con):
     assert df.equals(df2)
 
 
+def test_upsert_distinct(mysql_table, mysql_con):
+    create_table_sql = (
+        f"CREATE TABLE test.{mysql_table} " "(c0 varchar(100) NULL, " "c1 INT DEFAULT 42 NULL, " "c2 INT NOT NULL);"
+    )
+    with mysql_con.cursor() as cursor:
+        cursor.execute(create_table_sql)
+        mysql_con.commit()
+
+    df = pd.DataFrame({"c0": ["foo", "bar"], "c2": [1, 2]})
+
+    wr.mysql.to_sql(
+        df=df, con=mysql_con, schema="test", table=mysql_table, mode="upsert_distinct", use_column_names=True
+    )
+    wr.mysql.to_sql(
+        df=df, con=mysql_con, schema="test", table=mysql_table, mode="upsert_distinct", use_column_names=True
+    )
+    wr.mysql.to_sql(
+        df=df, con=mysql_con, schema="test", table=mysql_table, mode="upsert_distinct", use_column_names=True
+    )
+
+    df2 = wr.mysql.read_sql_table(con=mysql_con, schema="test", table=mysql_table)
+    assert bool(len(df2) == 2)
+
+
+def test_upsert_duplicate_key(mysql_table, mysql_con):
+    create_table_sql = (
+        f"CREATE TABLE test.{mysql_table} "
+        "(c0 varchar(100) PRIMARY KEY, "
+        "c1 INT DEFAULT 42 NULL, "
+        "c2 INT NOT NULL);"
+    )
+    with mysql_con.cursor() as cursor:
+        cursor.execute(create_table_sql)
+        mysql_con.commit()
+
+    df = pd.DataFrame({"c0": ["foo", "bar"], "c2": [1, 2]})
+
+    wr.mysql.to_sql(
+        df=df, con=mysql_con, schema="test", table=mysql_table, mode="upsert_duplicate_key", use_column_names=True
+    )
+    wr.mysql.to_sql(
+        df=df, con=mysql_con, schema="test", table=mysql_table, mode="upsert_duplicate_key", use_column_names=True
+    )
+    wr.mysql.to_sql(
+        df=df, con=mysql_con, schema="test", table=mysql_table, mode="upsert_duplicate_key", use_column_names=True
+    )
+
+    df2 = wr.mysql.read_sql_table(con=mysql_con, schema="test", table=mysql_table)
+    assert bool(len(df2) == 2)
+
+
+def test_upsert_replace(mysql_table, mysql_con):
+    create_table_sql = (
+        f"CREATE TABLE test.{mysql_table} "
+        "(c0 varchar(100) PRIMARY KEY, "
+        "c1 INT DEFAULT 42 NULL, "
+        "c2 INT NOT NULL);"
+    )
+    with mysql_con.cursor() as cursor:
+        cursor.execute(create_table_sql)
+        mysql_con.commit()
+
+    df = pd.DataFrame({"c0": ["foo", "bar"], "c2": [1, 2]})
+
+    wr.mysql.to_sql(
+        df=df, con=mysql_con, schema="test", table=mysql_table, mode="upsert_replace_into", use_column_names=True
+    )
+    wr.mysql.to_sql(
+        df=df, con=mysql_con, schema="test", table=mysql_table, mode="upsert_replace_into", use_column_names=True
+    )
+    wr.mysql.to_sql(
+        df=df, con=mysql_con, schema="test", table=mysql_table, mode="upsert_replace_into", use_column_names=True
+    )
+
+    df2 = wr.mysql.read_sql_table(con=mysql_con, schema="test", table=mysql_table)
+    assert bool(len(df2) == 2)
+
+
 @pytest.mark.parametrize("chunksize", [1, 10, 500])
 def test_dfs_are_equal_for_different_chunksizes(mysql_table, mysql_con, chunksize):
     df = pd.DataFrame({"c0": [i for i in range(64)], "c1": ["foo" for _ in range(64)]})

--- a/tests/test_mysql.py
+++ b/tests/test_mysql.py
@@ -216,12 +216,28 @@ def test_upsert_distinct(mysql_table, mysql_con):
     wr.mysql.to_sql(
         df=df, con=mysql_con, schema="test", table=mysql_table, mode="upsert_distinct", use_column_names=True
     )
+    df2 = wr.mysql.read_sql_table(con=mysql_con, schema="test", table=mysql_table)
+    assert bool(len(df2) == 2)
+
     wr.mysql.to_sql(
         df=df, con=mysql_con, schema="test", table=mysql_table, mode="upsert_distinct", use_column_names=True
     )
+    df3 = pd.DataFrame({"c0": ["baz", "bar"], "c2": [3, 2]})
+    wr.mysql.to_sql(
+        df=df3, con=mysql_con, schema="test", table=mysql_table, mode="upsert_distinct", use_column_names=True
+    )
+    df4 = wr.mysql.read_sql_table(con=mysql_con, schema="test", table=mysql_table)
+    assert bool(len(df4) == 3)
 
-    df2 = wr.mysql.read_sql_table(con=mysql_con, schema="test", table=mysql_table)
-    assert bool(len(df2) == 2)
+    df5 = pd.DataFrame({"c0": ["foo", "bar"], "c2": [4, 5]})
+    wr.mysql.to_sql(
+        df=df5, con=mysql_con, schema="test", table=mysql_table, mode="upsert_distinct", use_column_names=True
+    )
+    df6 = wr.mysql.read_sql_table(con=mysql_con, schema="test", table=mysql_table)
+    assert bool(len(df6) == 5)
+    assert bool(len(df6.loc[(df6["c0"] == "foo")]) == 2)
+    assert bool(len(df6.loc[(df6["c0"] == "foo") & (df6["c2"] == 4)]) == 1)
+    assert bool(len(df6.loc[(df6["c0"] == "bar") & (df6["c2"] == 5)]) == 1)
 
 
 def test_upsert_duplicate_key(mysql_table, mysql_con):
@@ -243,12 +259,28 @@ def test_upsert_duplicate_key(mysql_table, mysql_con):
     wr.mysql.to_sql(
         df=df, con=mysql_con, schema="test", table=mysql_table, mode="upsert_duplicate_key", use_column_names=True
     )
+    df2 = wr.mysql.read_sql_table(con=mysql_con, schema="test", table=mysql_table)
+    assert bool(len(df2) == 2)
+
     wr.mysql.to_sql(
         df=df, con=mysql_con, schema="test", table=mysql_table, mode="upsert_duplicate_key", use_column_names=True
     )
+    df3 = pd.DataFrame({"c0": ["baz", "bar"], "c2": [3, 2]})
+    wr.mysql.to_sql(
+        df=df3, con=mysql_con, schema="test", table=mysql_table, mode="upsert_duplicate_key", use_column_names=True
+    )
+    df4 = wr.mysql.read_sql_table(con=mysql_con, schema="test", table=mysql_table)
+    assert bool(len(df4) == 3)
 
-    df2 = wr.mysql.read_sql_table(con=mysql_con, schema="test", table=mysql_table)
-    assert bool(len(df2) == 2)
+    df5 = pd.DataFrame({"c0": ["foo", "bar"], "c2": [4, 5]})
+    wr.mysql.to_sql(
+        df=df5, con=mysql_con, schema="test", table=mysql_table, mode="upsert_duplicate_key", use_column_names=True
+    )
+
+    df6 = wr.mysql.read_sql_table(con=mysql_con, schema="test", table=mysql_table)
+    assert bool(len(df6) == 3)
+    assert bool(len(df6.loc[(df6["c0"] == "foo") & (df6["c2"] == 4)]) == 1)
+    assert bool(len(df6.loc[(df6["c0"] == "bar") & (df6["c2"] == 5)]) == 1)
 
 
 def test_upsert_replace(mysql_table, mysql_con):
@@ -270,12 +302,28 @@ def test_upsert_replace(mysql_table, mysql_con):
     wr.mysql.to_sql(
         df=df, con=mysql_con, schema="test", table=mysql_table, mode="upsert_replace_into", use_column_names=True
     )
+    df2 = wr.mysql.read_sql_table(con=mysql_con, schema="test", table=mysql_table)
+    assert bool(len(df2) == 2)
+
     wr.mysql.to_sql(
         df=df, con=mysql_con, schema="test", table=mysql_table, mode="upsert_replace_into", use_column_names=True
     )
+    df3 = pd.DataFrame({"c0": ["baz", "bar"], "c2": [3, 2]})
+    wr.mysql.to_sql(
+        df=df3, con=mysql_con, schema="test", table=mysql_table, mode="upsert_replace_into", use_column_names=True
+    )
+    df4 = wr.mysql.read_sql_table(con=mysql_con, schema="test", table=mysql_table)
+    assert bool(len(df4) == 3)
 
-    df2 = wr.mysql.read_sql_table(con=mysql_con, schema="test", table=mysql_table)
-    assert bool(len(df2) == 2)
+    df5 = pd.DataFrame({"c0": ["foo", "bar"], "c2": [4, 5]})
+    wr.mysql.to_sql(
+        df=df5, con=mysql_con, schema="test", table=mysql_table, mode="upsert_replace_into", use_column_names=True
+    )
+
+    df6 = wr.mysql.read_sql_table(con=mysql_con, schema="test", table=mysql_table)
+    assert bool(len(df6) == 3)
+    assert bool(len(df6.loc[(df6["c0"] == "foo") & (df6["c2"] == 4)]) == 1)
+    assert bool(len(df6.loc[(df6["c0"] == "bar") & (df6["c2"] == 5)]) == 1)
 
 
 @pytest.mark.parametrize("chunksize", [1, 10, 500])


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/awslabs/aws-data-wrangler/issues/608

*Description of changes:*
Adding basic upsert capabilities to `mysql.to_sql()` function. 

`mode` supports 3 new values:
- `upsert_duplicate_key`: Performs an upsert using `ON DUPLICATE KEY` clause. Requires table schema to have defined keys, otherwise duplicate records will be inserted.
- `upsert_replace_into`: Performs upsert using `REPLACE INTO` clause. Less efficient and still requires the table schema to have keys or else duplicate records will be inserted 
- `upsert_distinct`: Inserts new records, including duplicates, then recreates the table and inserts `DISTINCT` records from old table. This is the least efficient approach, but handles scenarios where there are no keys on table.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
