### PR TITLE
Raising exception when quality check fails

### DIFF
--- a/awswrangler/exceptions.py
+++ b/awswrangler/exceptions.py
@@ -103,3 +103,7 @@ class InvalidDataFrame(Exception):
 
 class InvalidFile(Exception):
     """InvalidFile."""
+
+
+class FailedQualityCheck(Exception):
+    """FailedQualityCheck."""

--- a/tests/test_s3_merge_upsert.py
+++ b/tests/test_s3_merge_upsert.py
@@ -5,6 +5,7 @@ import pandas as pd
 import pytest
 
 import awswrangler as wr
+from awswrangler.exceptions import FailedQualityCheck
 from awswrangler.s3._merge_upsert_table import _is_data_quality_sufficient, merge_upsert_table
 
 logger = logging.getLogger("awswrangler")
@@ -25,7 +26,8 @@ def test_is_data_quality_sufficient_mistmatch_column_names():
     existing_df = pd.DataFrame({"c0": [1, 2, 1, 2], "c1": [1, 2, 1, 2], "c2": [2, 1, 2, 1]})
     delta_df = pd.DataFrame({"d0": [1, 2, 1, 2], "d1": [1, 2, 1, 2], "c2": [2, 1, 2, 1]})
     primary_key = ["c0", "c1"]
-    assert _is_data_quality_sufficient(existing_df=existing_df, delta_df=delta_df, primary_key=primary_key) is False
+    with pytest.raises(FailedQualityCheck):
+        _is_data_quality_sufficient(existing_df=existing_df, delta_df=delta_df, primary_key=primary_key)
 
 
 def test_is_data_quality_sufficient_same_column_names_different_row_count():
@@ -33,7 +35,7 @@ def test_is_data_quality_sufficient_same_column_names_different_row_count():
     existing_df = pd.DataFrame([[1, 2, 3], [4, 5, 6], [7, 8, 9], [10, 11, 12]], columns=["col_a", "col_b", "col_c"])
     delta_df = pd.DataFrame([[1, 2, 3], [4, 5, 6], [7, 8, 9]], columns=["col_a", "col_b", "col_c"])
     primary_key = ["col_a", "col_b"]
-    assert _is_data_quality_sufficient(existing_df=existing_df, delta_df=delta_df, primary_key=primary_key) is True
+    assert _is_data_quality_sufficient(existing_df=existing_df, delta_df=delta_df, primary_key=primary_key)
 
 
 def test_is_data_quality_sufficient_missing_primary_key():
@@ -41,7 +43,8 @@ def test_is_data_quality_sufficient_missing_primary_key():
     existing_df = pd.DataFrame({"c0": [1, 2, 1], "c1": [1, 2, 1], "c2": [2, 1, 1]})
     delta_df = pd.DataFrame({"c0": [1, 2, 1, 2]})
     primary_key = ["c0", "c1"]
-    assert _is_data_quality_sufficient(existing_df=existing_df, delta_df=delta_df, primary_key=primary_key) is False
+    with pytest.raises(FailedQualityCheck):
+        _is_data_quality_sufficient(existing_df=existing_df, delta_df=delta_df, primary_key=primary_key)
 
 
 def test_is_data_quality_sufficient_fail_for_duplicate_data():
@@ -49,7 +52,8 @@ def test_is_data_quality_sufficient_fail_for_duplicate_data():
     existing_df = pd.DataFrame([[1, 2, 3], [1, 2, 3], [7, 8, 9], [10, 11, 12]], columns=["col_a", "col_b", "col_c"])
     delta_df = pd.DataFrame([[1, 2, 3], [4, 5, 6], [7, 8, 9]], columns=["col_a", "col_b", "col_c"])
     primary_key = ["col_a", "col_b"]
-    assert _is_data_quality_sufficient(existing_df=existing_df, delta_df=delta_df, primary_key=primary_key) is False
+    with pytest.raises(FailedQualityCheck):
+        _is_data_quality_sufficient(existing_df=existing_df, delta_df=delta_df, primary_key=primary_key)
 
 
 def test_table_does_not_exist(glue_database, glue_table):
@@ -65,7 +69,7 @@ def test_success_case(glue_database, glue_table, path):
         {"id": [1, 2], "cchar": ["foo", "boo"], "date": [datetime.date(2020, 1, 1), datetime.date(2020, 1, 2)]}
     )
     # Create the table
-    wr.s3.to_parquet(df=df, path=path, index=False, dataset=True, database=glue_database, table=glue_table)["paths"]
+    wr.s3.to_parquet(df=df, path=path, index=False, dataset=True, database=glue_database, table=glue_table)
     delta_df = pd.DataFrame({"id": [1], "cchar": ["foo"], "date": [datetime.date(2021, 1, 1)]})
     primary_key = ["id", "cchar"]
     merge_upsert_table(delta_df=delta_df, database=glue_database, table=glue_table, primary_key=primary_key)
@@ -79,7 +83,7 @@ def test_success_case2(glue_database, glue_table, path):
         {"id": [1, 2], "cchar": ["foo", "boo"], "date": [datetime.date(2020, 1, 1), datetime.date(2020, 1, 2)]}
     )
     # Create the table
-    wr.s3.to_parquet(df=df, path=path, index=False, dataset=True, database=glue_database, table=glue_table)["paths"]
+    wr.s3.to_parquet(df=df, path=path, index=False, dataset=True, database=glue_database, table=glue_table)
     delta_df = pd.DataFrame(
         {"id": [1, 2], "cchar": ["foo", "boo"], "date": [datetime.date(2021, 1, 1), datetime.date(2021, 1, 2)]}
     )


### PR DESCRIPTION
*Issue #, if available:*
#601

*Description of changes:*
Instead of skipping the merge silently, the method raises an error when the quality check fails.
The schema from each dataframe is converted to Arrow schema and compared.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
