### PR TITLE
Ensure the table path read by 'read_parquet_table()' ends with "/".

### DIFF
--- a/awswrangler/s3/_read_parquet.py
+++ b/awswrangler/s3/_read_parquet.py
@@ -771,8 +771,8 @@ def read_parquet_table(
         args["CatalogId"] = catalog_id
     res: Dict[str, Any] = client_glue.get_table(**args)
     try:
-        path: str = res["Table"]["StorageDescriptor"]["Location"]
-        path: str = path if path.endswith("/") else f"{path}/"
+        location: str = res["Table"]["StorageDescriptor"]["Location"]
+        path: str = location if location.endswith("/") else f"{location}/"
     except KeyError as ex:
         raise exceptions.InvalidTable(f"Missing s3 location for {database}.{table}.") from ex
     df = read_parquet(

--- a/awswrangler/s3/_read_parquet.py
+++ b/awswrangler/s3/_read_parquet.py
@@ -772,6 +772,7 @@ def read_parquet_table(
     res: Dict[str, Any] = client_glue.get_table(**args)
     try:
         path: str = res["Table"]["StorageDescriptor"]["Location"]
+        path: str = path if path.endswith("/") else f"{path}/"
     except KeyError as ex:
         raise exceptions.InvalidTable(f"Missing s3 location for {database}.{table}.") from ex
     df = read_parquet(


### PR DESCRIPTION
*Issue #638*

*Description of changes:*
Ensures that the path which is ultimately read when calling `read_parquet_table()` always ends with a "/" character.
This change avoids unwanted expansions when the `read_parquet()` function is called internally.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.