### PR TITLE
Fix get_query_column_types to return the correct format for decimal d…

### DIFF
--- a/awswrangler/athena/_utils.py
+++ b/awswrangler/athena/_utils.py
@@ -365,13 +365,12 @@ def get_query_columns_types(query_execution_id: str, boto3_session: Optional[bot
     client_athena: boto3.client = _utils.client(service_name="athena", session=boto3_session)
     response: Dict[str, Any] = client_athena.get_query_results(QueryExecutionId=query_execution_id, MaxResults=1)
     col_info: List[Dict[str, str]] = response["ResultSet"]["ResultSetMetadata"]["ColumnInfo"]
-    column_types: Dict[str, str] = {}
-    for col in col_info:
-        if col["Type"].lower() == "decimal":
-            column_types[col["Name"]] = "decimal(" + str(col["Precision"]) + "," + str(col.get("Scale", 0)) + ")"
-        else:
-            column_types[col["Name"]] = col["Type"]
-    return column_types
+    return dict(
+        (c["Name"], f"{c['Type']}({c['Precision']},{c.get('Scale', 0)})")
+        if c["Type"] in ["decimal"]
+        else (c["Name"], c["Type"])
+        for c in col_info
+    )
 
 
 def create_athena_bucket(boto3_session: Optional[boto3.Session] = None) -> str:

--- a/awswrangler/athena/_utils.py
+++ b/awswrangler/athena/_utils.py
@@ -365,7 +365,13 @@ def get_query_columns_types(query_execution_id: str, boto3_session: Optional[bot
     client_athena: boto3.client = _utils.client(service_name="athena", session=boto3_session)
     response: Dict[str, Any] = client_athena.get_query_results(QueryExecutionId=query_execution_id, MaxResults=1)
     col_info: List[Dict[str, str]] = response["ResultSet"]["ResultSetMetadata"]["ColumnInfo"]
-    return {x["Name"]: x["Type"] for x in col_info}
+    column_types: Dict[str, str] = {}
+    for col in col_info:
+        if col["Type"].lower() == 'decimal':
+            column_types[col["Name"]] = "decimal(" + str(col["Precision"]) + "," + str(col.get("Scale", 0)) + ")"
+        else:
+            column_types[col["Name"]] = col["Type"]
+    return column_types
 
 
 def create_athena_bucket(boto3_session: Optional[boto3.Session] = None) -> str:

--- a/awswrangler/athena/_utils.py
+++ b/awswrangler/athena/_utils.py
@@ -367,7 +367,7 @@ def get_query_columns_types(query_execution_id: str, boto3_session: Optional[bot
     col_info: List[Dict[str, str]] = response["ResultSet"]["ResultSetMetadata"]["ColumnInfo"]
     column_types: Dict[str, str] = {}
     for col in col_info:
-        if col["Type"].lower() == 'decimal':
+        if col["Type"].lower() == "decimal":
             column_types[col["Name"]] = "decimal(" + str(col["Precision"]) + "," + str(col.get("Scale", 0)) + ")"
         else:
             column_types[col["Name"]] = col["Type"]


### PR DESCRIPTION
the function get_query_data_types returns decimal types without the Precision and Scale attributes. This pull request corrects this.
*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
