### PR TITLE
Make use of pyarrow iter_batches

### DIFF
--- a/awswrangler/s3/_read_parquet.py
+++ b/awswrangler/s3/_read_parquet.py
@@ -279,6 +279,83 @@ def _arrowtable2df(
     return df
 
 
+def _iter_pyarrow_parquet_batches(
+    pq_file: pyarrow.parquet.ParquetFile,
+    chunked: Union[bool, int],
+    columns: Optional[List[str]],
+    categories: Optional[List[str]],
+    safe: bool,
+    map_types: bool,
+    dataset: bool,
+    path: str,
+    path_root: Optional[str],
+    use_threads: Union[bool, int],
+    use_threads_flag: bool,
+) -> Iterator[pd.DataFrame]:
+    batch_size = chunked if (isinstance(chunked, int) and chunked > 0) else 65_536
+    batches = pq_file.iter_batches(
+        batch_size=batch_size, columns=columns, use_threads=use_threads_flag, use_pandas_metadata=False
+    )
+    for batch in batches:
+        df: pd.DataFrame = _arrowtable2df(
+            table=batch,
+            categories=categories,
+            safe=safe,
+            map_types=map_types,
+            use_threads=use_threads,
+            dataset=dataset,
+            path=path,
+            path_root=path_root,
+        )
+        yield df
+
+
+def _iter_manual_parquet_batches(
+    pq_file: pyarrow.parquet.ParquetFile,
+    chunked: Union[bool, int],
+    ignore_index: Optional[bool],
+    columns: Optional[List[str]],
+    categories: Optional[List[str]],
+    safe: bool,
+    map_types: bool,
+    dataset: bool,
+    path: str,
+    path_root: Optional[str],
+    use_threads: Union[bool, int],
+    use_threads_flag: bool,
+    num_row_groups: int,
+) -> Iterator[pd.DataFrame]:
+    next_slice: Optional[pd.DataFrame] = None
+    for i in range(num_row_groups):
+        _logger.debug("Reading Row Group %s...", i)
+        df: pd.DataFrame = _arrowtable2df(
+            table=pq_file.read_row_group(i=i, columns=columns, use_threads=use_threads_flag, use_pandas_metadata=False),
+            categories=categories,
+            safe=safe,
+            map_types=map_types,
+            use_threads=use_threads,
+            dataset=dataset,
+            path=path,
+            path_root=path_root,
+        )
+        if chunked is True:
+            yield df
+        elif isinstance(chunked, int) and chunked > 0:
+            if next_slice is not None:
+                df = _union(dfs=[next_slice, df], ignore_index=ignore_index)
+            while len(df.index) >= chunked:
+                yield df.iloc[:chunked, :].copy()
+                df = df.iloc[chunked:, :]
+            if df.empty:
+                next_slice = None
+            else:
+                next_slice = df
+        else:
+            raise exceptions.InvalidArgument(f"chunked: {chunked}")
+    if next_slice is not None:
+        yield next_slice
+
+
 def _read_parquet_chunked(
     paths: List[str],
     chunked: Union[bool, int],
@@ -293,8 +370,7 @@ def _read_parquet_chunked(
     path_root: Optional[str],
     s3_additional_kwargs: Optional[Dict[str, str]],
     use_threads: Union[bool, int],
-) -> Iterator[pd.DataFrame]:  # pylint: disable=too-many-branches
-    next_slice: Optional[pd.DataFrame] = None
+) -> Iterator[pd.DataFrame]:
     last_schema: Optional[Dict[str, str]] = None
     last_path: str = ""
     for path in paths:
@@ -327,36 +403,37 @@ def _read_parquet_chunked(
             num_row_groups: int = pq_file.num_row_groups
             _logger.debug("num_row_groups: %s", num_row_groups)
             use_threads_flag: bool = use_threads if isinstance(use_threads, bool) else bool(use_threads > 1)
-            for i in range(num_row_groups):
-                _logger.debug("Reading Row Group %s...", i)
-                df: pd.DataFrame = _arrowtable2df(
-                    table=pq_file.read_row_group(
-                        i=i, columns=columns, use_threads=use_threads_flag, use_pandas_metadata=False
-                    ),
+            # iter_batches is only available for pyarrow >= 3.0.0
+            if callable(getattr(pq_file, "iter_batches", None)):
+                yield from _iter_pyarrow_parquet_batches(
+                    pq_file=pq_file,
+                    chunked=chunked,
+                    columns=columns,
                     categories=categories,
                     safe=safe,
                     map_types=map_types,
-                    use_threads=use_threads,
                     dataset=dataset,
                     path=path,
                     path_root=path_root,
+                    use_threads=use_threads,
+                    use_threads_flag=use_threads_flag,
                 )
-                if chunked is True:
-                    yield df
-                elif isinstance(chunked, int) and chunked > 0:
-                    if next_slice is not None:
-                        df = _union(dfs=[next_slice, df], ignore_index=ignore_index)
-                    while len(df.index) >= chunked:
-                        yield df.iloc[:chunked, :].copy()
-                        df = df.iloc[chunked:, :]
-                    if df.empty:
-                        next_slice = None
-                    else:
-                        next_slice = df
-                else:
-                    raise exceptions.InvalidArgument(f"chunked: {chunked}")
-    if next_slice is not None:
-        yield next_slice
+            else:
+                yield from _iter_manual_parquet_batches(
+                    pq_file=pq_file,
+                    chunked=chunked,
+                    ignore_index=ignore_index,
+                    columns=columns,
+                    categories=categories,
+                    safe=safe,
+                    map_types=map_types,
+                    dataset=dataset,
+                    path=path,
+                    path_root=path_root,
+                    use_threads=use_threads,
+                    use_threads_flag=use_threads_flag,
+                    num_row_groups=num_row_groups,
+                )
 
 
 def _read_parquet_file(


### PR DESCRIPTION
*Issue #660:*

*Description of changes:*
When available make use of the new `pyarrow` function `iter_batches`, but keep the old mechanism as a fallback for `pyarrow < 3.0.0`. 

I've opted for explicitly checking for the availability of `iter_batches` instead of a try except block, because of the `for` loop over the batches and to make sure that the two parsing mechanisms don't get mixed up in case of an unexpected exception.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
