### PR TITLE
Add dtypes for empty ctas athena queries

### DIFF
--- a/awswrangler/athena/_read.py
+++ b/awswrangler/athena/_read.py
@@ -236,15 +236,15 @@ def _fetch_parquet_result(  # pylint: disable=too-many-return-statements
     if not paths:
         if not temp_table_identifier:
             return _empty_dataframe_response(bool(chunked), query_metadata)
+        if chunked:
+            return ()
         database, temp_table_name = map(lambda x: x.replace('"', ""), temp_table_identifier.split("."))
         dtype_df = catalog.table(database=database, table=temp_table_name)
         dtype_dict = {row["Column Name"]: row["Type"] for (idx, row) in dtype_df.iterrows()}
         df = pd.DataFrame(columns=list(dtype_dict.keys()))
         df = cast_pandas_with_athena_types(df=df, dtype=dtype_dict)
         df = _apply_query_metadata(df=df, query_metadata=query_metadata)
-        if chunked is False:
-            return df
-        return (e for e in [df])
+        return df
     ret = s3.read_parquet(
         path=paths,
         use_threads=use_threads,

--- a/tests/test_athena.py
+++ b/tests/test_athena.py
@@ -252,7 +252,7 @@ def test_athena_ctas_empty(glue_database):
     df1 = wr.athena.read_sql_query(sql=sql, database=glue_database)
     assert df1.empty is True
     ensure_athena_query_metadata(df=df1, ctas_approach=True, encrypted=False)
-    assert len(list(wr.athena.read_sql_query(sql=sql, database=glue_database, chunksize=1))) == 0
+    assert len(list(wr.athena.read_sql_query(sql=sql, database=glue_database, chunksize=1))) == 1
 
 
 def test_athena_struct(glue_database):

--- a/tests/test_athena_parquet.py
+++ b/tests/test_athena_parquet.py
@@ -611,6 +611,22 @@ def test_partitions_overwrite(path, glue_table, glue_database, use_threads, part
     assert df.iint8.sum() == df2.iint8.sum()
 
 
+def test_empty_dataframe(path, glue_database, glue_table, chunksize):
+    df = get_df_list()
+    wr.s3.to_parquet(
+        df=df,
+        path=path,
+        dataset=True,
+        database=glue_database,
+        table=glue_table,
+    )
+    sql = f"SELECT * FROM {glue_table} WHERE par0 = :par0;"
+    df_uncached = wr.athena.read_sql_query(sql=sql, database=glue_database, ctas_approach=True, params={"par0": 999})
+    df_cached = wr.athena.read_sql_query(sql=sql, database=glue_database, ctas_approach=True, params={"par0": 999})
+    assert set(df.columns) == set(df_uncached.columns)
+    assert set(df.columns) == set(df_cached.columns)
+
+
 @pytest.mark.parametrize("use_threads", [True, False])
 def test_empty_column(path, glue_table, glue_database, use_threads):
     df = pd.DataFrame({"c0": [1, 2, 3], "c1": [None, None, None], "par": ["a", "b", "c"]})

--- a/tests/test_athena_parquet.py
+++ b/tests/test_athena_parquet.py
@@ -611,7 +611,7 @@ def test_partitions_overwrite(path, glue_table, glue_database, use_threads, part
     assert df.iint8.sum() == df2.iint8.sum()
 
 
-def test_empty_dataframe(path, glue_database, glue_table, chunksize):
+def test_empty_dataframe(path, glue_database, glue_table):
     df = get_df_list()
     wr.s3.to_parquet(
         df=df,


### PR DESCRIPTION
*Issue #659:*

*Description of changes:*
When the result of a Athena CTAS query is empty, the column names and data types are retrieved from the create Glue table as a backup. 
However this is not possible for cached queries, as the Glue table does not exist anymore.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
