### PR TITLE
Pass SSL properties from Glue Connection to MySQL

### DIFF
--- a/awswrangler/mysql.py
+++ b/awswrangler/mysql.py
@@ -78,9 +78,14 @@ def connect(
     write_timeout: Optional[int] = None,
     connect_timeout: int = 10,
 ) -> pymysql.connections.Connection:
-    """Return a pymysql connection from a Glue Catalog Connection.
+    """Return a pymysql connection from a Glue Catalog Connection or Secrets Manager.
 
     https://pymysql.readthedocs.io
+
+    Note
+    ----
+    It is only possible to configure SSL using Glue Catalog Connection. More at:
+    https://docs.aws.amazon.com/glue/latest/dg/connection-defining.html
 
     Parameters
     ----------
@@ -136,10 +141,10 @@ def connect(
         password=attrs.password,
         port=attrs.port,
         host=attrs.host,
+        ssl=attrs.ssl_context,
         read_timeout=read_timeout,
         write_timeout=write_timeout,
         connect_timeout=connect_timeout,
-        ssl=attrs.ssl_context,
     )
 
 

--- a/awswrangler/mysql.py
+++ b/awswrangler/mysql.py
@@ -139,6 +139,7 @@ def connect(
         read_timeout=read_timeout,
         write_timeout=write_timeout,
         connect_timeout=connect_timeout,
+        ssl=attrs.ssl_context,
     )
 
 

--- a/cloudformation/databases.yaml
+++ b/cloudformation/databases.yaml
@@ -384,6 +384,32 @@ Resources:
           PASSWORD:
             Ref: DatabasesPassword
         Name: aws-data-wrangler-mysql
+  MysqlGlueConnectionSSL:
+    Type: AWS::Glue::Connection
+    Properties:
+      CatalogId:
+        Ref: AWS::AccountId
+      ConnectionInput:
+        Description: Connect to Aurora (MySQL).
+        ConnectionType: JDBC
+        PhysicalConnectionRequirements:
+          AvailabilityZone:
+            Fn::Select:
+              - 0
+              - Fn::GetAZs: ''
+          SecurityGroupIdList:
+            - Ref: DatabaseSecurityGroup
+          SubnetId:
+            Fn::ImportValue: aws-data-wrangler-base-PrivateSubnet
+        ConnectionProperties:
+          JDBC_CONNECTION_URL:
+            Fn::Sub: jdbc:mysql://${AuroraInstanceMysql.Endpoint.Address}:${AuroraInstanceMysql.Endpoint.Port}/test
+          JDBC_ENFORCE_SSL: true
+          CUSTOM_JDBC_CERT: s3://rds-downloads/rds-combined-ca-bundle.pem
+          USERNAME: test
+          PASSWORD:
+            Ref: DatabasesPassword
+        Name: aws-data-wrangler-mysql-ssl
   SqlServerGlueConnection:
     Type: AWS::Glue::Connection
     Properties:

--- a/cloudformation/databases.yaml
+++ b/cloudformation/databases.yaml
@@ -390,7 +390,7 @@ Resources:
       CatalogId:
         Ref: AWS::AccountId
       ConnectionInput:
-        Description: Connect to Aurora (MySQL).
+        Description: Connect to Aurora (MySQL) SSL enabled.
         ConnectionType: JDBC
         PhysicalConnectionRequirements:
           AvailabilityZone:

--- a/tests/test_mysql.py
+++ b/tests/test_mysql.py
@@ -20,12 +20,16 @@ def mysql_con():
     con.close()
 
 
-def test_connection():
-    wr.mysql.connect("aws-data-wrangler-mysql", connect_timeout=10).close()
+@pytest.fixture(scope="function")
+def mysql_con_ssl():
+    con = wr.mysql.connect("aws-data-wrangler-mysql-ssl")
+    yield con
+    con.close()
 
 
-def test_connection_ssl():
-    wr.mysql.connect("aws-data-wrangler-mysql-ssl", connect_timeout=10).close()
+@pytest.mark.parametrize("connection", ["aws-data-wrangler-mysql", "aws-data-wrangler-mysql-ssl"])
+def test_connection(connection):
+    wr.mysql.connect(connection, connect_timeout=10).close()
 
 
 def test_read_sql_query_simple(databases_parameters):
@@ -44,6 +48,11 @@ def test_read_sql_query_simple(databases_parameters):
 def test_to_sql_simple(mysql_table, mysql_con):
     df = pd.DataFrame({"c0": [1, 2, 3], "c1": ["foo", "boo", "bar"]})
     wr.mysql.to_sql(df, mysql_con, mysql_table, "test", "overwrite", True)
+
+
+def test_to_sql_simple_ssl(mysql_table, mysql_con_ssl):
+    df = pd.DataFrame({"c0": [1, 2, 3], "c1": ["foo", "boo", "bar"]})
+    wr.mysql.to_sql(df, mysql_con_ssl, mysql_table, "test", "overwrite", True)
 
 
 def test_sql_types(mysql_table, mysql_con):

--- a/tests/test_mysql.py
+++ b/tests/test_mysql.py
@@ -24,6 +24,10 @@ def test_connection():
     wr.mysql.connect("aws-data-wrangler-mysql", connect_timeout=10).close()
 
 
+def test_connection_ssl():
+    wr.mysql.connect("aws-data-wrangler-mysql-ssl", connect_timeout=10).close()
+
+
 def test_read_sql_query_simple(databases_parameters):
     con = pymysql.connect(
         host=databases_parameters["mysql"]["host"],


### PR DESCRIPTION
*Issue [#554](https://github.com/awslabs/aws-data-wrangler/issues/554):*

*Description of changes:*
Pass SSL properties from Glue Connection to PyMySQL. ~~Depends on [this PyMySQL PR](https://github.com/PyMySQL/PyMySQL/pull/980) merged & released first. ~~

UPD: In conversation with PyMySQL contributors it seems it's possible to pass `SSLContext` to PyMySQL so extra argument is not required anymore.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
