### PR TITLE
Extending logic to add_csv_partitions and leveraging catalog_table_input

### DIFF
--- a/awswrangler/catalog/_add.py
+++ b/awswrangler/catalog/_add.py
@@ -48,10 +48,12 @@ def add_csv_partitions(
     catalog_id: Optional[str] = None,
     compression: Optional[str] = None,
     sep: str = ",",
+    serde_library: Optional[str] = None,
+    serde_parameters: Optional[Dict[str, str]] = None,
     boto3_session: Optional[boto3.Session] = None,
     columns_types: Optional[Dict[str, str]] = None,
 ) -> None:
-    """Add partitions (metadata) to a CSV Table in the AWS Glue Catalog.
+    r"""Add partitions (metadata) to a CSV Table in the AWS Glue Catalog.
 
     Parameters
     ----------
@@ -73,6 +75,13 @@ def add_csv_partitions(
         Compression style (``None``, ``gzip``, etc).
     sep : str
         String of length 1. Field delimiter for the output file.
+    serde_library : Optional[str]
+        Specifies the SerDe Serialization library which will be used. You need to provide the Class library name
+        as a string.
+        If no library is provided the default is `org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe`.
+    serde_parameters : Optional[str]
+        Dictionary of initialization parameters for the SerDe.
+        The default is `{"field.delim": sep, "escape.delim": "\\"}`.
     boto3_session : boto3.Session(), optional
         Boto3 Session. The default boto3 session will be used if boto3_session receive None.
     columns_types: Optional[Dict[str, str]]
@@ -107,6 +116,8 @@ def add_csv_partitions(
             compression=compression,
             sep=sep,
             columns_types=columns_types,
+            serde_library=serde_library,
+            serde_parameters=serde_parameters,
         )
         for k, v in partitions_values.items()
     ]

--- a/awswrangler/catalog/_definitions.py
+++ b/awswrangler/catalog/_definitions.py
@@ -152,19 +152,24 @@ def _csv_partition_definition(
     bucketing_info: Optional[Tuple[List[str], int]],
     compression: Optional[str],
     sep: str,
+    serde_library: Optional[str],
+    serde_parameters: Optional[Dict[str, str]],
     columns_types: Optional[Dict[str, str]],
 ) -> Dict[str, Any]:
     compressed: bool = compression is not None
+    serde_info = {
+        "SerializationLibrary": "org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe"
+        if serde_library is None
+        else serde_library,
+        "Parameters": {"field.delim": sep, "escape.delim": "\\"} if serde_parameters is None else serde_parameters,
+    }
     definition: Dict[str, Any] = {
         "StorageDescriptor": {
             "InputFormat": "org.apache.hadoop.mapred.TextInputFormat",
             "OutputFormat": "org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat",
             "Location": location,
             "Compressed": compressed,
-            "SerdeInfo": {
-                "Parameters": {"field.delim": sep, "escape.delim": "\\"},
-                "SerializationLibrary": "org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe",
-            },
+            "SerdeInfo": serde_info,
             "StoredAsSubDirectories": False,
             "NumberOfBuckets": -1 if bucketing_info is None else bucketing_info[1],
             "BucketColumns": [] if bucketing_info is None else bucketing_info[0],

--- a/awswrangler/s3/_write_text.py
+++ b/awswrangler/s3/_write_text.py
@@ -501,6 +501,11 @@ def to_csv(  # pylint: disable=too-many-arguments,too-many-locals,too-many-state
                 columns_types, partitions_types = _data_types.athena_types_from_pandas_partitioned(
                     df=df, index=index, partition_cols=partition_cols, dtype=dtype, index_left=True
                 )
+                serde_info: Dict[str, Any] = {}
+                if catalog_table_input:
+                    serde_info = catalog_table_input["StorageDescriptor"]["SerdeInfo"]
+                serde_library: Optional[str] = serde_info.get("SerializationLibrary", None)
+                serde_parameters: Optional[Dict[str, str]] = serde_info.get("Parameters", None)
                 catalog._create_csv_table(  # pylint: disable=protected-access
                     database=database,
                     table=table,
@@ -525,8 +530,8 @@ def to_csv(  # pylint: disable=too-many-arguments,too-many-locals,too-many-state
                     catalog_id=catalog_id,
                     compression=pandas_kwargs.get("compression"),
                     skip_header_line_count=None,
-                    serde_library=None,
-                    serde_parameters=None,
+                    serde_library=serde_library,
+                    serde_parameters=serde_parameters,
                 )
                 if partitions_values and (regular_partitions is True):
                     _logger.debug("partitions_values:\n%s", partitions_values)
@@ -537,6 +542,8 @@ def to_csv(  # pylint: disable=too-many-arguments,too-many-locals,too-many-state
                         bucketing_info=bucketing_info,
                         boto3_session=session,
                         sep=sep,
+                        serde_library=serde_library,
+                        serde_parameters=serde_parameters,
                         catalog_id=catalog_id,
                         columns_types=columns_types,
                         compression=pandas_kwargs.get("compression"),


### PR DESCRIPTION
*Issue #, if available:*
#672

*Description of changes:*
Added some enhancements to previous PR #673
- Leverage the `catalog_table_input` details when available to extract serde info from existing catalog tables
- Extend the logic to the `add_csv_partitions` method

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
