### PR TITLE
Add Redshift overwrite methods

### DIFF
--- a/tests/test_redshift.py
+++ b/tests/test_redshift.py
@@ -42,9 +42,10 @@ def test_read_sql_query_simple(databases_parameters):
     assert df.shape == (1, 1)
 
 
-def test_to_sql_simple(redshift_table, redshift_con):
+@pytest.mark.parametrize("overwrite_method", [None, "drop", "cascade", "truncate", "delete"])
+def test_to_sql_simple(redshift_table, redshift_con, overwrite_method):
     df = pd.DataFrame({"c0": [1, 2, 3], "c1": ["foo", "boo", "bar"]})
-    wr.redshift.to_sql(df, redshift_con, redshift_table, "public", "overwrite", True)
+    wr.redshift.to_sql(df, redshift_con, redshift_table, "public", "overwrite", overwrite_method, True)
 
 
 def test_sql_types(redshift_table, redshift_con):


### PR DESCRIPTION
*Issue #671:*

*Description of changes:*
Add `overwrite_method = "drop" | "cascade" | "truncate" | "delete"` parameter to determine the way the table should be overwritten.

`drop` - plain `DROP ...` (`RESTRICT` by default) - drops the table, but will fail if there are any views that depend on it.
`cascade` - `DROP ... CASCADE` - drops the table, and all views that depend on it.
`truncate` - `TRUNCATE ...` - truncates the table, but [commits the current transaction](https://docs.aws.amazon.com/redshift/latest/dg/r_TRUNCATE.html), hence the overwrite is **not atomic**.
`delete` - `DELETE FROM ...` - deletes all rows from the table within the current transaction. Slow relative to the other methods.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
