### PR TITLE
Fix bucketing types

### DIFF
--- a/awswrangler/s3/_write_dataset.py
+++ b/awswrangler/s3/_write_dataset.py
@@ -81,7 +81,7 @@ def _to_buckets(
     **func_kwargs: Any,
 ) -> List[str]:
     _proxy: _WriteProxy = proxy if proxy else _WriteProxy(use_threads=False)
-    bucket_number_series = df.apply(
+    bucket_number_series = df.astype("O").apply(
         lambda row: _get_bucket_number(bucketing_info[1], [row[col_name] for col_name in bucketing_info[0]]),
         axis="columns",
     )


### PR DESCRIPTION
*Description of changes:*
During testing some bucketing I've noticed a problem when there are combined datatypes in some rows which cause dtype casting during `df.apply`. As during `df.apply` each row is handled as a separate Series and for example there is a `float` and a `int` column, the `dtype` of the row series is `float` and the [Exception](https://github.com/awslabs/aws-data-wrangler/blob/main/awswrangler/s3/_write_dataset.py#L124) is raised.

To prevent this issue the fix according to https://stackoverflow.com/a/47145613/10608063 was added which changes the `dtype` to `object` before `apply`.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
