### PR TITLE
Removing explicit Excel engine configuration

### DIFF
--- a/awswrangler/s3/_read_excel.py
+++ b/awswrangler/s3/_read_excel.py
@@ -77,6 +77,5 @@ def read_excel(
         s3_additional_kwargs=s3_additional_kwargs,
         boto3_session=session,
     ) as f:
-        pandas_kwargs["engine"] = "openpyxl"
         _logger.debug("pandas_kwargs: %s", pandas_kwargs)
         return pd.read_excel(f, **pandas_kwargs)

--- a/awswrangler/s3/_read_excel.py
+++ b/awswrangler/s3/_read_excel.py
@@ -28,6 +28,11 @@ def read_excel(
 
     Note
     ----
+    Depending on the file extension ('xlsx', 'xls', 'odf'...), an additional library
+    might have to be installed first (e.g. xlrd).
+
+    Note
+    ----
     In case of `use_threads=True` the number of threads
     that will be spawned will be gotten from os.cpu_count().
 

--- a/awswrangler/s3/_write_excel.py
+++ b/awswrangler/s3/_write_excel.py
@@ -83,7 +83,6 @@ def to_excel(
         s3_additional_kwargs=s3_additional_kwargs,
         boto3_session=session,
     ) as f:
-        pandas_kwargs["engine"] = "openpyxl"
         _logger.debug("pandas_kwargs: %s", pandas_kwargs)
         df.to_excel(f, **pandas_kwargs)
     return path

--- a/awswrangler/s3/_write_excel.py
+++ b/awswrangler/s3/_write_excel.py
@@ -29,6 +29,11 @@ def to_excel(
 
     Note
     ----
+    Depending on the file extension ('xlsx', 'xls', 'odf'...), an additional library
+    might have to be installed first (e.g. xlrd).
+
+    Note
+    ----
     In case of `use_threads=True` the number of threads
     that will be spawned will be gotten from os.cpu_count().
 

--- a/tests/test_s3_excel.py
+++ b/tests/test_s3_excel.py
@@ -8,12 +8,12 @@ import awswrangler as wr
 logging.getLogger("awswrangler").setLevel(logging.DEBUG)
 
 
+@pytest.mark.parametrize("ext", ["xlsx", "xlsm", "xls", "odf"])
 @pytest.mark.parametrize("use_threads", [True, False, 2])
-def test_excel(path, use_threads):
+def test_excel(path, ext, use_threads):
     df = pd.DataFrame({"c0": [1, 2, 3], "c1": ["foo", "boo", "bar"]})
 
-    for ext in ["xlsx", "xlsm", "xls", "odf"]:
-        file_path = f"{path}0.{ext}"
-        wr.s3.to_excel(df, file_path, use_threads=use_threads, index=False)
-        df2 = wr.s3.read_excel(file_path, use_threads=use_threads)
-        assert df.equals(df2)
+    file_path = f"{path}0.{ext}"
+    wr.s3.to_excel(df, file_path, use_threads=use_threads, index=False)
+    df2 = wr.s3.read_excel(file_path, use_threads=use_threads)
+    assert df.equals(df2)

--- a/tests/test_s3_excel.py
+++ b/tests/test_s3_excel.py
@@ -10,8 +10,10 @@ logging.getLogger("awswrangler").setLevel(logging.DEBUG)
 
 @pytest.mark.parametrize("use_threads", [True, False, 2])
 def test_excel(path, use_threads):
-    file_path = f"{path}0.xlsx"
     df = pd.DataFrame({"c0": [1, 2, 3], "c1": ["foo", "boo", "bar"]})
-    wr.s3.to_excel(df, file_path, use_threads=use_threads, index=False)
-    df2 = wr.s3.read_excel(file_path, use_threads=use_threads)
-    assert df.equals(df2)
+
+    for ext in ["xlsx", "xlsm", "xls", "odf"]:
+        file_path = f"{path}0.{ext}"
+        wr.s3.to_excel(df, file_path, use_threads=use_threads, index=False)
+        df2 = wr.s3.read_excel(file_path, use_threads=use_threads)
+        assert df.equals(df2)


### PR DESCRIPTION
*Issue #, if available:*
#739 

*Description of changes:*
Removing explicit Excel engine configuration from s3 read and write excel methods. Instead, Wrangler delegates engine choice to Pandas.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
