### PR TITLE
Add VersionId parameter for S3 reads

### DIFF
--- a/awswrangler/s3/_download.py
+++ b/awswrangler/s3/_download.py
@@ -14,6 +14,7 @@ _logger: logging.Logger = logging.getLogger(__name__)
 def download(
     path: str,
     local_file: Union[str, Any],
+    version_id: Optional[str] = None,
     use_threads: bool = True,
     boto3_session: Optional[boto3.Session] = None,
     s3_additional_kwargs: Optional[Dict[str, Any]] = None,
@@ -31,6 +32,8 @@ def download(
         S3 path (e.g. ``s3://bucket/key0``).
     local_file : Union[str, Any]
         A file-like object in binary mode or a path to local file (e.g. ``./local/path/to/key0``).
+    version_id: Optional[str]
+        Version id of the object.
     use_threads : bool
         True to enable concurrent requests, False to disable multiple threads.
         If enabled os.cpu_count() will be used as the max number of threads.
@@ -64,6 +67,7 @@ def download(
         path=path,
         mode="rb",
         use_threads=use_threads,
+        version_id=version_id,
         s3_block_size=-1,  # One shot download
         s3_additional_kwargs=s3_additional_kwargs,
         boto3_session=session,

--- a/awswrangler/s3/_list.py
+++ b/awswrangler/s3/_list.py
@@ -137,7 +137,10 @@ def _list_objects(  # pylint: disable=too-many-branches
 
 
 def does_object_exist(
-    path: str, s3_additional_kwargs: Optional[Dict[str, Any]] = None, boto3_session: Optional[boto3.Session] = None
+    path: str,
+    s3_additional_kwargs: Optional[Dict[str, Any]] = None,
+    boto3_session: Optional[boto3.Session] = None,
+    version_id: Optional[str] = None,
 ) -> bool:
     """Check if object exists on S3.
 
@@ -187,6 +190,8 @@ def does_object_exist(
     else:
         extra_kwargs = {}
     try:
+        if version_id:
+            extra_kwargs["VersionId"] = version_id
         client_s3.head_object(Bucket=bucket, Key=key, **extra_kwargs)
         return True
     except botocore.exceptions.ClientError as ex:

--- a/awswrangler/s3/_read_excel.py
+++ b/awswrangler/s3/_read_excel.py
@@ -14,6 +14,7 @@ _logger: logging.Logger = logging.getLogger(__name__)
 
 def read_excel(
     path: str,
+    version_id: Optional[str] = None,
     use_threads: Union[bool, int] = True,
     boto3_session: Optional[boto3.Session] = None,
     s3_additional_kwargs: Optional[Dict[str, Any]] = None,
@@ -38,8 +39,10 @@ def read_excel(
 
     Parameters
     ----------
-    path : Union[str, List[str]]
+    path : str
         S3 path (e.g. ``s3://bucket/key.xlsx``).
+    version_id : Optional[str]
+        Version id of the object.
     use_threads : Union[bool, int]
         True to enable concurrent requests, False to disable multiple threads.
         If enabled os.cpu_count() will be used as the max number of threads.
@@ -77,6 +80,7 @@ def read_excel(
     with open_s3_object(
         path=path,
         mode="rb",
+        version_id=version_id,
         use_threads=use_threads,
         s3_block_size=-1,  # One shot download
         s3_additional_kwargs=s3_additional_kwargs,

--- a/test_infra/stacks/base_stack.py
+++ b/test_infra/stacks/base_stack.py
@@ -58,6 +58,7 @@ class BaseStack(cdk.Stack):  # type: ignore
                     abort_incomplete_multipart_upload_after=cdk.Duration.days(1),
                 ),
             ],
+            versioned=True,
         )
         glue_db = glue.Database(
             self,

--- a/tests/test_s3_excel.py
+++ b/tests/test_s3_excel.py
@@ -17,3 +17,14 @@ def test_excel(path, ext, use_threads):
     wr.s3.to_excel(df, file_path, use_threads=use_threads, index=False)
     df2 = wr.s3.read_excel(file_path, use_threads=use_threads)
     assert df.equals(df2)
+
+
+def test_read_xlsx_versioned(path) -> None:
+    path_file = f"{path}0.xlsx"
+    dfs = [pd.DataFrame({"c0": [0, 1, 2], "c1": [3, 4, 5]}), pd.DataFrame({"c0": [3, 4, 5], "c1": [6, 7, 8]})]
+    for df in dfs:
+        wr.s3.to_excel(df=df, path=path_file, index=False)
+        version_id = wr.s3.describe_objects(path=path_file)[path_file]["VersionId"]
+        df_temp = wr.s3.read_excel(path_file, version_id=version_id)
+        assert df_temp.equals(df)
+        assert version_id == wr.s3.describe_objects(path=path_file, version_id=version_id)[path_file]["VersionId"]


### PR DESCRIPTION
*Issue #721 *

*Description of changes:*
Add `version_id: Optional[Union[str, Dict[str, str]]]` parameter to S3 read operations to be able to query specific versions of an object or mulptiple objects. The parameter, depending on the context of the operation, may be either a single version id string or a dictionary `object key -> version id`.

Tests coming up.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
