### PR TITLE
Minor - Adding unload format to unload_files

### DIFF
--- a/tests/test_redshift.py
+++ b/tests/test_redshift.py
@@ -352,7 +352,10 @@ def test_unload_extras(bucket, path, redshift_table, redshift_con, databases_par
     assert len(df.columns) == 2
 
 
-def test_unload_with_prefix(bucket, path, redshift_table, redshift_con, databases_parameters, kms_key_id):
+@pytest.mark.parametrize("unload_format", [None, "CSV", "PARQUET"])
+def test_unload_with_prefix(
+    bucket, path, redshift_table, redshift_con, databases_parameters, kms_key_id, unload_format
+):
     test_prefix = "my_prefix"
     table = redshift_table
     schema = databases_parameters["redshift"]["schema"]
@@ -367,6 +370,7 @@ def test_unload_with_prefix(bucket, path, redshift_table, redshift_con, database
         "region": wr.s3.get_bucket_region(bucket),
         "max_file_size": 5.0,
         "kms_key_id": kms_key_id,
+        "unload_format": unload_format,
     }
     # Adding a prefix to S3 output files
     wr.redshift.unload_to_files(**args)


### PR DESCRIPTION
*Issue #, if available:*
#760 

*Description of changes:*
Adding an `unload_format` parameter to the `wr.redshift.unload_files` method, enabling unloading files as a CSV instead of just parquet. Parameter defaults to PARQUET if None is supplied, meaning the change is backward compatible.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
