### PR TITLE
Add boto3_session parameter to catalog.get_table_types

### DIFF
--- a/awswrangler/athena/_read.py
+++ b/awswrangler/athena/_read.py
@@ -237,7 +237,7 @@ def _fetch_parquet_result(
         if not temp_table_fqn:
             raise exceptions.EmptyDataFrame("Query would return untyped, empty dataframe.")
         database, temp_table_name = map(lambda x: x.replace('"', ""), temp_table_fqn.split("."))
-        dtype_dict = catalog.get_table_types(database=database, table=temp_table_name)
+        dtype_dict = catalog.get_table_types(database=database, table=temp_table_name, boto3_session=boto3_session)
         df = pd.DataFrame(columns=list(dtype_dict.keys()))
         df = cast_pandas_with_athena_types(df=df, dtype=dtype_dict)
         df = _apply_query_metadata(df=df, query_metadata=query_metadata)


### PR DESCRIPTION
Athena read_sql_query was raising errors locally when using given boto3_session, because the catalog.get_table_types call didn't get the boto3_session from caller.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
