### PR TITLE
Handle empty table corner case

### DIFF
--- a/awswrangler/_databases.py
+++ b/awswrangler/_databases.py
@@ -143,16 +143,19 @@ def _records2df(
                 array = pa.array(obj=col_values, safe=safe)  # Creating Arrow array
                 array = array.cast(target_type=dtype[col_name], safe=safe)  # Casting
         arrays.append(array)
-    table = pa.Table.from_arrays(arrays=arrays, names=cols_names)  # Creating arrow Table
-    df: pd.DataFrame = table.to_pandas(  # Creating Pandas DataFrame
-        use_threads=True,
-        split_blocks=True,
-        self_destruct=True,
-        integer_object_nulls=False,
-        date_as_object=True,
-        types_mapper=_data_types.pyarrow2pandas_extension,
-        safe=safe,
-    )
+    if not arrays:
+        df = pd.DataFrame(columns=cols_names)
+    else:
+        table = pa.Table.from_arrays(arrays=arrays, names=cols_names)  # Creating arrow Table
+        df = table.to_pandas(  # Creating Pandas DataFrame
+            use_threads=True,
+            split_blocks=True,
+            self_destruct=True,
+            integer_object_nulls=False,
+            date_as_object=True,
+            types_mapper=_data_types.pyarrow2pandas_extension,
+            safe=safe,
+        )
     if index is not None:
         df.set_index(index, inplace=True)
     return df

--- a/tests/test_redshift.py
+++ b/tests/test_redshift.py
@@ -48,6 +48,13 @@ def test_to_sql_simple(redshift_table, redshift_con, overwrite_method):
     wr.redshift.to_sql(df, redshift_con, redshift_table, "public", "overwrite", overwrite_method, True)
 
 
+def test_empty_table(redshift_table, redshift_con):
+    with redshift_con.cursor() as cursor:
+        cursor.execute(f"CREATE TABLE public.{redshift_table}(c0 integer not null, c1 integer, primary key(c0));")
+    df = wr.redshift.read_sql_table(table=redshift_table, con=redshift_con, schema="public")
+    assert df.columns.values.tolist() == ["c0", "c1"]
+
+
 def test_sql_types(redshift_table, redshift_con):
     table = redshift_table
     df = get_df()


### PR DESCRIPTION
*Issue #, if available:*
#874 

*Description of changes:*
Handle the edge case where the Redshift table is empty. Currently an empty dataframe with no columns is returned. Fix returns an empty dataframe but with columns

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
