### PR TITLE
Adding backticks to insertion columns names

### DIFF
--- a/awswrangler/mysql.py
+++ b/awswrangler/mysql.py
@@ -383,7 +383,7 @@ def to_sql(
             upsert_columns = ""
             upsert_str = ""
             if use_column_names:
-                insertion_columns = f"({', '.join(df.columns)})"
+                insertion_columns = f"(`{'`, `'.join(df.columns)}`)"
             if mode == "upsert_duplicate_key":
                 upsert_columns = ", ".join(df.columns.map(lambda column: f"`{column}`=VALUES(`{column}`)"))
                 upsert_str = f" ON DUPLICATE KEY UPDATE {upsert_columns}"


### PR DESCRIPTION
*Issue #, if available:*
#918 

*Description of changes:*

Adding backtick to column names in wr.mysql.to_sql to allow columns with names the same as reserved words to be used when using use_column_names=True

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
