### PR TITLE
Fixes #592

### DIFF
--- a/awswrangler/_data_types.py
+++ b/awswrangler/_data_types.py
@@ -701,3 +701,11 @@ def timestream_type_from_pandas(df: pd.DataFrame) -> str:
     pyarrow_type: pa.DataType = list(pyarrow_types.values())[0]
     _logger.debug("pyarrow_type: %s", pyarrow_type)
     return pyarrow2timestream(dtype=pyarrow_type)
+
+
+def _get_arrow_timestamp_unit(data_type: pa.lib.DataType) -> str:
+    """Returns unit of pyarrow timestamp. If the pyarrow type is not timestamp then None is returned"""
+    if isinstance(data_type, pa.lib.TimestampType):
+        return data_type.unit
+    else:
+        return None


### PR DESCRIPTION
*Issue #592*

*Description of changes:*
- Allows user to pass `coerce_int96_timestamp_unit` in a pyarrow_additional_kwargs dict. This avoids integer overflow error when reading Parquet INT96 types into Arrow.
- Parquet reader will return a timestamp as a column of datetime objs rather than pd.Timestamps if any column in the table has a timestamp unit that is not nanosecond.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
