### PR TITLE
Fix typo in _write.parquet.py/store_parquet_metadata doc

### DIFF
--- a/awswrangler/s3/_write_parquet.py
+++ b/awswrangler/s3/_write_parquet.py
@@ -666,7 +666,7 @@ def store_parquet_metadata(  # pylint: disable=too-many-arguments
 
     Infer Apache Parquet file(s) metadata from from a received S3 prefix or list of S3 objects paths
     And then stores it on AWS Glue Catalog including all inferred partitions
-    (No need of 'MCSK REPAIR TABLE')
+    (No need of 'MSCK REPAIR TABLE')
 
     The concept of Dataset goes beyond the simple idea of files and enable more
     complex features like partitioning and catalog integration (AWS Glue Catalog).


### PR DESCRIPTION
*Description of changes:*
I just noticed that the letters of `MSCK REPAIR TABLE` in the documentation of `awswrangler.s3.store_parquet_metadata` are swapped. This PR fixes the typo.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
