### PR TITLE
Allow all Python 3.10 versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
 ]
 
 [tool.poetry.dependencies]
-python = ">=3.6.2, <=3.10.0"
+python = ">=3.6.2, <=3.10"
 
 boto3 = "^1.20.17"
 botocore = "^1.23.17"


### PR DESCRIPTION
If you try to install aws-data-wrangler with the current Python version `3.10.1` it says
it's not compatible and you only get offered a really old version 0.3.2.

This change makes it compatible with all Python 3.10 versions.
