### PR TITLE
Allow all Python 3.10 versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
 ]
 
 [tool.poetry.dependencies]
-python = ">=3.6.2, <=3.10"
+python = ">=3.6.2, <3.11"
 
 boto3 = "^1.20.17"
 botocore = "^1.23.17"

--- a/test_infra/pyproject.toml
+++ b/test_infra/pyproject.toml
@@ -6,7 +6,7 @@ authors = ["Amazon Web Services"]
 license = "Apache License 2.0"
 
 [tool.poetry.dependencies]
-python = ">=3.6.2, <3.10"
+python = ">=3.6.2, <3.11"
 "aws-cdk.core" = "^1.124.0"
 "aws-cdk.aws-ec2" = "^1.124.0"
 "aws-cdk.aws-glue" = "^1.124.0"


### PR DESCRIPTION
Dropping only the patch version doesn't work with poetry
as it still thinks version 3.10.1 is larger than "<=3.10".

So we'll simply allow everything below 3.11.

See the wrong PR from
https://github.com/awslabs/aws-data-wrangler/pull/1071