### PR TITLE
fix(s3.list): type hinting for chunked arg

### DIFF
--- a/awswrangler/s3/_list.py
+++ b/awswrangler/s3/_list.py
@@ -3,7 +3,8 @@
 import datetime
 import fnmatch
 import logging
-from typing import Any, Dict, Iterator, List, Optional, Sequence, Union
+from typing import Any, Dict, Iterator, List, Optional, overload, Sequence, Union
+from typing_extensions import Literal
 
 import boto3
 import botocore.exceptions
@@ -265,6 +266,36 @@ def list_directories(
     if chunked:
         return result_iterator
     return [path for paths in result_iterator for path in paths]
+
+
+@overload
+def list_objects(
+    path: str,
+    suffix: Union[str, List[str], None] = None,
+    ignore_suffix: Union[str, List[str], None] = None,
+    last_modified_begin: Optional[datetime.datetime] = None,
+    last_modified_end: Optional[datetime.datetime] = None,
+    ignore_empty: bool = False,
+    chunked: Literal[False] = False,
+    s3_additional_kwargs: Optional[Dict[str, Any]] = None,
+    boto3_session: Optional[boto3.Session] = None,
+) -> List[str]:
+    ...
+
+
+@overload
+def list_objects(
+    path: str,
+    suffix: Union[str, List[str], None] = None,
+    ignore_suffix: Union[str, List[str], None] = None,
+    last_modified_begin: Optional[datetime.datetime] = None,
+    last_modified_end: Optional[datetime.datetime] = None,
+    ignore_empty: bool = False,
+    chunked: bool = False,
+    s3_additional_kwargs: Optional[Dict[str, Any]] = None,
+    boto3_session: Optional[boto3.Session] = None,
+) -> Union[List[str], Iterator[List[str]]]:
+    ...
 
 
 def list_objects(


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Fixing the return type of `s3.list_objects` to account for the `chunked` arg by using typing.overload.  

Currently, I have to use `cast` in a lot of places (40+ and growing). `cast` is confusing to data scientists who consume the code base, as they think it is actually casting the value or haven't seen it before. This addition allows the correct return type to be reported based on the args passed. It will save quite a bit of overhead on the user end.

If this is agreeable, I would be happy to take on some of the other functions that have chunking. 

```python
from typing import cast, List
import awswrangler as wr

# Mypy issues, and runtime issues if you try to index a 
# generator
thing = wr.s3.list_objects("thing", chunked=True)[0]

# No mypy issues nor runtime issues, this will return a list
thing = wr.s3.list_objects("thing")[0]

# Currently I have to do this all over the code base (not using chunked)
# Or even worse... #type: ignore it
thing = cast(List[str], wr.s3.list_objects("thing"))[0]
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
