### PR TITLE
Append incremental n to duplicate cols recursively

### DIFF
--- a/awswrangler/catalog/__init__.py
+++ b/awswrangler/catalog/__init__.py
@@ -42,7 +42,7 @@ from awswrangler.catalog._get import (  # noqa
 from awswrangler.catalog._utils import (  # noqa
     does_table_exist,
     drop_duplicated_columns,
-    rename_duplicate_columns,
+    rename_duplicated_columns,
     extract_athena_types,
     sanitize_column_name,
     sanitize_dataframe_columns_names,

--- a/awswrangler/catalog/__init__.py
+++ b/awswrangler/catalog/__init__.py
@@ -42,6 +42,7 @@ from awswrangler.catalog._get import (  # noqa
 from awswrangler.catalog._utils import (  # noqa
     does_table_exist,
     drop_duplicated_columns,
+    rename_duplicate_columns,
     extract_athena_types,
     sanitize_column_name,
     sanitize_dataframe_columns_names,

--- a/awswrangler/catalog/__init__.py
+++ b/awswrangler/catalog/__init__.py
@@ -42,8 +42,8 @@ from awswrangler.catalog._get import (  # noqa
 from awswrangler.catalog._utils import (  # noqa
     does_table_exist,
     drop_duplicated_columns,
-    rename_duplicated_columns,
     extract_athena_types,
+    rename_duplicated_columns,
     sanitize_column_name,
     sanitize_dataframe_columns_names,
     sanitize_table_name,
@@ -58,6 +58,7 @@ __all__ = [
     "delete_column",
     "drop_duplicated_columns",
     "extract_athena_types",
+    "rename_duplicated_columns",
     "sanitize_column_name",
     "sanitize_dataframe_columns_names",
     "sanitize_table_name",

--- a/awswrangler/catalog/_utils.py
+++ b/awswrangler/catalog/_utils.py
@@ -214,7 +214,8 @@ def sanitize_dataframe_columns_names(
     """
     df.columns = [sanitize_column_name(x) for x in df.columns]
     df.index.names = [None if x is None else sanitize_column_name(x) for x in df.index.names]
-    if len(set(df.columns)) != len(df.columns):
+    # Ignore mypy error from pandas.DataFrame.columns.duplicated().any()
+    if df.columns.duplicated.any():  # type:ignore
         if handle_duplicate_columns == "warn":
             warnings.warn(
                 "Some columns names are duplicated, consider using `handle_duplicate_columns='[drop|rename]'`",

--- a/awswrangler/catalog/_utils.py
+++ b/awswrangler/catalog/_utils.py
@@ -130,12 +130,11 @@ def rename_duplicated_columns(df: pd.DataFrame) -> pd.DataFrame:
 
     Note
     ----
-    This transformation will run `inplace` and will make changes in the original DataFrame.
+    This transformation will run `inplace` and will make changes to the original DataFrame.
 
     Note
     ----
-    Also handles potential new duplicated conflicts by appending another `_n`
-    to the end of the column name if it conflicts.
+    Also handles potential new column duplicate conflicts by appending an additional `_n`.
 
     Parameters
     ----------
@@ -165,7 +164,6 @@ def rename_duplicated_columns(df: pd.DataFrame) -> pd.DataFrame:
     while df.columns.duplicated().any():
         # Catches edge cases where pd.DataFrame({"A": [1, 2], "a": [3, 4], "a_1": [5, 6]})
         df = rename_duplicated_columns(df)
-
     return df
 
 
@@ -179,7 +177,6 @@ def sanitize_dataframe_columns_names(
     Possible transformations:
     - Strip accents
     - Remove non alphanumeric characters
-    - Convert CamelCase to snake_case
 
     Note
     ----
@@ -192,8 +189,9 @@ def sanitize_dataframe_columns_names(
         Original Pandas DataFrame.
     handle_duplicate_columns : str, optional
         How to handle duplicate columns. Can be "warn" or "drop" or "rename".
-        The default is "warn". "drop" will drop all but the first duplicated column.
+        "drop" will drop all but the first duplicated column.
         "rename" will rename all duplicated columns with an incremental number.
+        Defaults to "warn".
 
     Returns
     -------
@@ -214,23 +212,18 @@ def sanitize_dataframe_columns_names(
     """
     df.columns = [sanitize_column_name(x) for x in df.columns]
     df.index.names = [None if x is None else sanitize_column_name(x) for x in df.index.names]
-    # Ignore mypy error from pandas.DataFrame.columns.duplicated().any()
-    if df.columns.duplicated.any():  # type:ignore
+    if df.columns.duplicated().any():  # type: ignore
         if handle_duplicate_columns == "warn":
             warnings.warn(
-                "Some columns names are duplicated, consider using `handle_duplicate_columns='[drop|rename]'`",
+                "Duplicate columns were detected, consider using `handle_duplicate_columns='[drop|rename]'`",
                 UserWarning,
             )
-
         elif handle_duplicate_columns == "drop":
             df = drop_duplicated_columns(df)
-
         elif handle_duplicate_columns == "rename":
             df = rename_duplicated_columns(df)
-
         else:
             raise ValueError("handle_duplicate_columns must be one of ['warn', 'drop', 'rename']")
-
     return df
 
 

--- a/awswrangler/catalog/_utils.py
+++ b/awswrangler/catalog/_utils.py
@@ -125,13 +125,13 @@ def sanitize_column_name(column: str) -> str:
     return _sanitize_name(name=column)
 
 
-def rename_duplicate_columns(df: pd.DataFrame) -> pd.DataFrame:
+def rename_duplicated_columns(df: pd.DataFrame) -> pd.DataFrame:
     """Append an incremental number to duplicate column names to conform with Amazon Athena.
     
     Also handles potential new duplicated conflicts by appending another `_n`
     to the end of the column name if it conflicts.
 
-    >>> df_rename = wr.catalog.rename_duplicate_columns(df=pd.DataFrame({'A': [1, 2], 'a': [3, 4], 'a_1': [4, 6]}))
+    >>> df_rename = wr.catalog.rename_duplicated_columns(df=pd.DataFrame({'A': [1, 2], 'a': [3, 4], 'a_1': [4, 6]}))
     """
     names = df.columns
     name_df = pd.DataFrame(names, columns=["name"])
@@ -141,7 +141,7 @@ def rename_duplicate_columns(df: pd.DataFrame) -> pd.DataFrame:
     df.columns = name_df.new_names.values
     while df.columns.duplicated().any():
                 # Catches edge cases where pd.DataFrame({"A": [1, 2], "a": [3, 4], "a_1": [5, 6]})
-                df = rename_duplicate_columns(df)
+                df = rename_duplicated_columns(df)
     return df
 
 
@@ -191,7 +191,7 @@ def sanitize_dataframe_columns_names(df: pd.DataFrame, handle_dup_cols: Optional
             df = drop_duplicated_columns(df)
             
         elif handle_dup_cols == "rename":
-            df = rename_duplicate_columns(df)
+            df = rename_duplicated_columns(df)
             
         else:
             raise ValueError("handle_dup_cols must be one of ['warn', 'drop', 'rename']")

--- a/awswrangler/catalog/_utils.py
+++ b/awswrangler/catalog/_utils.py
@@ -194,6 +194,7 @@ def sanitize_dataframe_columns_names(
         How to handle duplicate columns. Can be "warn" or "drop" or "rename".
         The default is "warn". "drop" will drop all but the first duplicated column.
         "rename" will rename all duplicated columns with an incremental number.
+
     Returns
     -------
     pandas.DataFrame
@@ -202,13 +203,18 @@ def sanitize_dataframe_columns_names(
     Examples
     --------
     >>> import awswrangler as wr
-    >>> df_normalized = wr.catalog.sanitize_dataframe_columns_names(df=pd.DataFrame({'A': [1, 2]}))
-    >>> df_normalized_drop = wr.catalog.sanitize_dataframe_columns_names(df=pd.DataFrame({'A': [1, 2], 'a': [3, 4]}), handle_duplicate_columns="drop")
-    >>> df_normalized_rename = wr.catalog.sanitize_dataframe_columns_names(df=pd.DataFrame({'A': [1, 2], 'a': [3, 4], 'a_1': [4, 6]}), handle_duplicate_columns="rename")
+    >>> df_normalized = wr.catalog.sanitize_dataframe_columns_names(df=pd.DataFrame({"A": [1, 2]}))
+    >>> df_normalized_drop = wr.catalog.sanitize_dataframe_columns_names(
+            df=pd.DataFrame({"A": [1, 2], "a": [3, 4]}), handle_duplicate_columns="drop"
+        )
+    >>> df_normalized_rename = wr.catalog.sanitize_dataframe_columns_names(
+            df=pd.DataFrame({"A": [1, 2], "a": [3, 4], "a_1": [4, 6]}), handle_duplicate_columns="rename"
+        )
+
     """
     df.columns = [sanitize_column_name(x) for x in df.columns]
     df.index.names = [None if x is None else sanitize_column_name(x) for x in df.index.names]
-    if len(set(df.columns)) != len(df.columns):  # df.columns.duplicated().any():
+    if len(set(df.columns)) != len(df.columns):
         if handle_duplicate_columns == "warn":
             warnings.warn(
                 "Some columns names are duplicated, consider using `handle_duplicate_columns='[drop|rename]'`",

--- a/awswrangler/catalog/_utils.py
+++ b/awswrangler/catalog/_utils.py
@@ -134,14 +134,15 @@ def rename_duplicated_columns(df: pd.DataFrame) -> pd.DataFrame:
     >>> df_rename = wr.catalog.rename_duplicated_columns(df=pd.DataFrame({'A': [1, 2], 'a': [3, 4], 'a_1': [4, 6]}))
     """
     names = df.columns
-    name_df = pd.DataFrame(names, columns=["name"])
-    name_df["col_count"] = name_df.groupby("name").cumcount().astype(str)
-    name_df["new_names"] = name_df["name"]
-    name_df.loc[name_df.col_count > "0", "new_names"] += "_" + name_df.col_count
-    df.columns = name_df.new_names.values
+    set_names = set(names)
+    if len(names) == len(set_names):
+        return df
+    d = {key: [name + f"_{i}"  if i > 0 else name for i, name in enumerate(names[names==key])] for key in set_names}
+    df.rename(columns=lambda c: d[c].pop(0), inplace=True)
     while df.columns.duplicated().any():
                 # Catches edge cases where pd.DataFrame({"A": [1, 2], "a": [3, 4], "a_1": [5, 6]})
                 df = rename_duplicated_columns(df)
+    
     return df
 
 

--- a/awswrangler/catalog/_utils.py
+++ b/awswrangler/catalog/_utils.py
@@ -127,7 +127,7 @@ def sanitize_column_name(column: str) -> str:
 
 def rename_duplicated_columns(df: pd.DataFrame) -> pd.DataFrame:
     """Append an incremental number to duplicate column names to conform with Amazon Athena.
-    
+
     Also handles potential new duplicated conflicts by appending another `_n`
     to the end of the column name if it conflicts.
 
@@ -137,16 +137,18 @@ def rename_duplicated_columns(df: pd.DataFrame) -> pd.DataFrame:
     set_names = set(names)
     if len(names) == len(set_names):
         return df
-    d = {key: [name + f"_{i}"  if i > 0 else name for i, name in enumerate(names[names==key])] for key in set_names}
+    d = {key: [name + f"_{i}" if i > 0 else name for i, name in enumerate(names[names == key])] for key in set_names}
     df.rename(columns=lambda c: d[c].pop(0), inplace=True)
     while df.columns.duplicated().any():
-                # Catches edge cases where pd.DataFrame({"A": [1, 2], "a": [3, 4], "a_1": [5, 6]})
-                df = rename_duplicated_columns(df)
-    
+        # Catches edge cases where pd.DataFrame({"A": [1, 2], "a": [3, 4], "a_1": [5, 6]})
+        df = rename_duplicated_columns(df)
+
     return df
 
 
-def sanitize_dataframe_columns_names(df: pd.DataFrame, handle_duplicate_columns: Optional[str] = "warn") -> pd.DataFrame:
+def sanitize_dataframe_columns_names(
+    df: pd.DataFrame, handle_duplicate_columns: Optional[str] = "warn"
+) -> pd.DataFrame:
     """Normalize all columns names to be compatible with Amazon Athena.
 
     https://docs.aws.amazon.com/athena/latest/ug/tables-databases-columns-names.html
@@ -185,15 +187,16 @@ def sanitize_dataframe_columns_names(df: pd.DataFrame, handle_duplicate_columns:
     df.index.names = [None if x is None else sanitize_column_name(x) for x in df.index.names]
     if df.columns.duplicated().any():
         if handle_duplicate_columns == "warn":
-            warnings.warn("Some columns names are duplicated, consider using "+
-                          "`handle_duplicate_columns='[drop|rename]'`")
+            warnings.warn(
+                "Some columns names are duplicated, consider using " + "`handle_duplicate_columns='[drop|rename]'`"
+            )
 
         elif handle_duplicate_columns == "drop":
             df = drop_duplicated_columns(df)
-            
+
         elif handle_duplicate_columns == "rename":
             df = rename_duplicated_columns(df)
-            
+
         else:
             raise ValueError("handle_duplicate_columns must be one of ['warn', 'drop', 'rename']")
 

--- a/awswrangler/catalog/_utils.py
+++ b/awswrangler/catalog/_utils.py
@@ -2,8 +2,8 @@
 import logging
 import re
 import unicodedata
-from typing import Any, Dict, List, Optional, Tuple
 import warnings
+from typing import Any, Dict, List, Optional, Tuple
 
 import boto3
 import pandas as pd

--- a/awswrangler/catalog/_utils.py
+++ b/awswrangler/catalog/_utils.py
@@ -208,7 +208,7 @@ def sanitize_dataframe_columns_names(
     """
     df.columns = [sanitize_column_name(x) for x in df.columns]
     df.index.names = [None if x is None else sanitize_column_name(x) for x in df.index.names]
-    if df.columns.duplicated().any():
+    if len(set(df.columns)) != len(df.columns):  # df.columns.duplicated().any():
         if handle_duplicate_columns == "warn":
             warnings.warn(
                 "Some columns names are duplicated, consider using `handle_duplicate_columns='[drop|rename]'`",

--- a/awswrangler/catalog/_utils.py
+++ b/awswrangler/catalog/_utils.py
@@ -212,7 +212,7 @@ def sanitize_dataframe_columns_names(
         if handle_duplicate_columns == "warn":
             warnings.warn(
                 "Some columns names are duplicated, consider using `handle_duplicate_columns='[drop|rename]'`",
-                UserWarning
+                UserWarning,
             )
 
         elif handle_duplicate_columns == "drop":

--- a/awswrangler/catalog/_utils.py
+++ b/awswrangler/catalog/_utils.py
@@ -128,10 +128,33 @@ def sanitize_column_name(column: str) -> str:
 def rename_duplicated_columns(df: pd.DataFrame) -> pd.DataFrame:
     """Append an incremental number to duplicate column names to conform with Amazon Athena.
 
+    Note
+    ----
+    This transformation will run `inplace` and will make changes in the original DataFrame.
+
+    Note
+    ----
     Also handles potential new duplicated conflicts by appending another `_n`
     to the end of the column name if it conflicts.
 
-    >>> df_rename = wr.catalog.rename_duplicated_columns(df=pd.DataFrame({'A': [1, 2], 'a': [3, 4], 'a_1': [4, 6]}))
+    Parameters
+    ----------
+    df : pandas.DataFrame
+        Original Pandas DataFrame.
+    
+    Returns
+    -------
+    pandas.DataFrame
+        DataFrame with duplicated column names renamed.
+
+    Examples
+    --------
+    >>> df = pd.DataFrame({'a': [1, 2], 'b': [3, 4], 'c': [4, 6]})
+    >>> df.columns = ['a', 'a', 'a_1']
+    >>> wr.catalog.rename_duplicated_columns(df=df)
+    a	a_1	a_1_1
+    1	3	4
+    2	4	6
     """
     names = df.columns
     set_names = set(names)

--- a/awswrangler/catalog/_utils.py
+++ b/awswrangler/catalog/_utils.py
@@ -141,7 +141,7 @@ def rename_duplicated_columns(df: pd.DataFrame) -> pd.DataFrame:
     ----------
     df : pandas.DataFrame
         Original Pandas DataFrame.
-    
+
     Returns
     -------
     pandas.DataFrame

--- a/awswrangler/catalog/_utils.py
+++ b/awswrangler/catalog/_utils.py
@@ -211,7 +211,8 @@ def sanitize_dataframe_columns_names(
     if df.columns.duplicated().any():
         if handle_duplicate_columns == "warn":
             warnings.warn(
-                "Some columns names are duplicated, consider using " + "`handle_duplicate_columns='[drop|rename]'`"
+                "Some columns names are duplicated, consider using `handle_duplicate_columns='[drop|rename]'`",
+                UserWarning
             )
 
         elif handle_duplicate_columns == "drop":

--- a/awswrangler/catalog/_utils.py
+++ b/awswrangler/catalog/_utils.py
@@ -146,7 +146,7 @@ def rename_duplicated_columns(df: pd.DataFrame) -> pd.DataFrame:
     return df
 
 
-def sanitize_dataframe_columns_names(df: pd.DataFrame, handle_dup_cols: Optional[str] = "warn") -> pd.DataFrame:
+def sanitize_dataframe_columns_names(df: pd.DataFrame, handle_duplicate_columns: Optional[str] = "warn") -> pd.DataFrame:
     """Normalize all columns names to be compatible with Amazon Athena.
 
     https://docs.aws.amazon.com/athena/latest/ug/tables-databases-columns-names.html
@@ -165,7 +165,7 @@ def sanitize_dataframe_columns_names(df: pd.DataFrame, handle_dup_cols: Optional
     ----------
     df : pandas.DataFrame
         Original Pandas DataFrame.
-    handle_dup_cols : str, optional
+    handle_duplicate_columns : str, optional
         How to handle duplicate columns. Can be "warn" or "drop" or "rename".
         The default is "warn". "drop" will drop all but the first duplicated column.
         "rename" will rename all duplicated columns with an incremental number.
@@ -178,24 +178,24 @@ def sanitize_dataframe_columns_names(df: pd.DataFrame, handle_dup_cols: Optional
     --------
     >>> import awswrangler as wr
     >>> df_normalized = wr.catalog.sanitize_dataframe_columns_names(df=pd.DataFrame({'A': [1, 2]}))
-    >>> df_normalized_drop = wr.catalog.sanitize_dataframe_columns_names(df=pd.DataFrame({'A': [1, 2], 'a': [3, 4]}), handle_dup_cols="drop")
-    >>> df_normalized_rename = wr.catalog.sanitize_dataframe_columns_names(df=pd.DataFrame({'A': [1, 2], 'a': [3, 4], 'a_1': [4, 6]}), handle_dup_cols="rename")
+    >>> df_normalized_drop = wr.catalog.sanitize_dataframe_columns_names(df=pd.DataFrame({'A': [1, 2], 'a': [3, 4]}), handle_duplicate_columns="drop")
+    >>> df_normalized_rename = wr.catalog.sanitize_dataframe_columns_names(df=pd.DataFrame({'A': [1, 2], 'a': [3, 4], 'a_1': [4, 6]}), handle_duplicate_columns="rename")
     """
     df.columns = [sanitize_column_name(x) for x in df.columns]
     df.index.names = [None if x is None else sanitize_column_name(x) for x in df.index.names]
     if df.columns.duplicated().any():
-        if handle_dup_cols == "warn":
+        if handle_duplicate_columns == "warn":
             warnings.warn("Some columns names are duplicated, consider using "+
-                          "`handle_dup_cols='[drop|rename]'`")
+                          "`handle_duplicate_columns='[drop|rename]'`")
 
-        elif handle_dup_cols == "drop":
+        elif handle_duplicate_columns == "drop":
             df = drop_duplicated_columns(df)
             
-        elif handle_dup_cols == "rename":
+        elif handle_duplicate_columns == "rename":
             df = rename_duplicated_columns(df)
             
         else:
-            raise ValueError("handle_dup_cols must be one of ['warn', 'drop', 'rename']")
+            raise ValueError("handle_duplicate_columns must be one of ['warn', 'drop', 'rename']")
 
     return df
 

--- a/tests/test_athena.py
+++ b/tests/test_athena.py
@@ -247,9 +247,15 @@ def test_athena_read_list(glue_database):
 
 
 def test_sanitize_dataframe_column_names():
-    assert  wr.catalog.sanitize_dataframe_columns_names(df=pd.DataFrame({'A': [1, 2]})).equals(pd.DataFrame({'a': [1, 2]})) # Unsure how to test for warnings
-    assert wr.catalog.sanitize_dataframe_columns_names(df=pd.DataFrame({'A': [1, 2], 'a': [3, 4]}), handle_duplicate_columns="drop").equals(pd.DataFrame({'a': [1, 2]}))
-    assert wr.catalog.sanitize_dataframe_columns_names(df=pd.DataFrame({'A': [1, 2], 'a': [3, 4], 'a_1': [5, 6]}), handle_duplicate_columns="rename").equals(pd.DataFrame({'a': [1, 2], 'a_1': [3, 4], 'a_1_1': [5, 6]}))
+    assert wr.catalog.sanitize_dataframe_columns_names(df=pd.DataFrame({"A": [1, 2]})).equals(
+        pd.DataFrame({"a": [1, 2]})
+    )  # Unsure how to test for warnings
+    assert wr.catalog.sanitize_dataframe_columns_names(
+        df=pd.DataFrame({"A": [1, 2], "a": [3, 4]}), handle_duplicate_columns="drop"
+    ).equals(pd.DataFrame({"a": [1, 2]}))
+    assert wr.catalog.sanitize_dataframe_columns_names(
+        df=pd.DataFrame({"A": [1, 2], "a": [3, 4], "a_1": [5, 6]}), handle_duplicate_columns="rename"
+    ).equals(pd.DataFrame({"a": [1, 2], "a_1": [3, 4], "a_1_1": [5, 6]}))
 
 
 def test_sanitize_names():

--- a/tests/test_athena.py
+++ b/tests/test_athena.py
@@ -246,6 +246,12 @@ def test_athena_read_list(glue_database):
         wr.athena.read_sql_query(sql="SELECT ARRAY[1, 2, 3]", database=glue_database, ctas_approach=False)
 
 
+def test_sanitize_dataframe_column_names():
+    assert  wr.catalog.sanitize_dataframe_columns_names(df=pd.DataFrame({'A': [1, 2]})).equals(pd.DataFrame({'a': [1, 2]})) # Unsure how to test for warnings
+    assert wr.catalog.sanitize_dataframe_columns_names(df=pd.DataFrame({'A': [1, 2], 'a': [3, 4]}), handle_dup_cols="drop").equals(pd.DataFrame({'a': [1, 2]}))
+    assert wr.catalog.sanitize_dataframe_columns_names(df=pd.DataFrame({'A': [1, 2], 'a': [3, 4], 'a_1': [5, 6]}), handle_dup_cols="rename").equals(pd.DataFrame({'a': [1, 2], 'a_1': [3, 4], 'a_1_1': [5, 6]}))
+
+
 def test_sanitize_names():
     assert wr.catalog.sanitize_column_name("CamelCase") == "camelcase"
     assert wr.catalog.sanitize_column_name("CamelCase2") == "camelcase2"

--- a/tests/test_athena.py
+++ b/tests/test_athena.py
@@ -250,9 +250,7 @@ def test_sanitize_dataframe_column_names():
     with pytest.warns(UserWarning, match=r"Some*"):
         test_df = pd.DataFrame({"a": [1, 2], "b": [3, 4]})
         test_df.columns = ["a", "a"]
-        assert wr.catalog.sanitize_dataframe_columns_names(df=pd.DataFrame({"A": [1, 2], "a": [3, 4]})).equals(
-           test_df
-    )
+        assert wr.catalog.sanitize_dataframe_columns_names(df=pd.DataFrame({"A": [1, 2], "a": [3, 4]})).equals(test_df)
     assert wr.catalog.sanitize_dataframe_columns_names(
         df=pd.DataFrame({"A": [1, 2], "a": [3, 4]}), handle_duplicate_columns="drop"
     ).equals(pd.DataFrame({"a": [1, 2]}))

--- a/tests/test_athena.py
+++ b/tests/test_athena.py
@@ -247,9 +247,12 @@ def test_athena_read_list(glue_database):
 
 
 def test_sanitize_dataframe_column_names():
-    assert wr.catalog.sanitize_dataframe_columns_names(df=pd.DataFrame({"A": [1, 2]})).equals(
-        pd.DataFrame({"a": [1, 2]})
-    )  # Unsure how to test for warnings
+    with pytest.warns(UserWarning, match=r"Some*"):
+        test_df = pd.DataFrame({"a": [1, 2], "b": [3, 4]})
+        test_df.columns = ["a", "a"]
+        assert wr.catalog.sanitize_dataframe_columns_names(df=pd.DataFrame({"A": [1, 2], "a": [3, 4]})).equals(
+           test_df
+    )
     assert wr.catalog.sanitize_dataframe_columns_names(
         df=pd.DataFrame({"A": [1, 2], "a": [3, 4]}), handle_duplicate_columns="drop"
     ).equals(pd.DataFrame({"a": [1, 2]}))

--- a/tests/test_athena.py
+++ b/tests/test_athena.py
@@ -248,8 +248,8 @@ def test_athena_read_list(glue_database):
 
 def test_sanitize_dataframe_column_names():
     assert  wr.catalog.sanitize_dataframe_columns_names(df=pd.DataFrame({'A': [1, 2]})).equals(pd.DataFrame({'a': [1, 2]})) # Unsure how to test for warnings
-    assert wr.catalog.sanitize_dataframe_columns_names(df=pd.DataFrame({'A': [1, 2], 'a': [3, 4]}), handle_dup_cols="drop").equals(pd.DataFrame({'a': [1, 2]}))
-    assert wr.catalog.sanitize_dataframe_columns_names(df=pd.DataFrame({'A': [1, 2], 'a': [3, 4], 'a_1': [5, 6]}), handle_dup_cols="rename").equals(pd.DataFrame({'a': [1, 2], 'a_1': [3, 4], 'a_1_1': [5, 6]}))
+    assert wr.catalog.sanitize_dataframe_columns_names(df=pd.DataFrame({'A': [1, 2], 'a': [3, 4]}), handle_duplicate_columns="drop").equals(pd.DataFrame({'a': [1, 2]}))
+    assert wr.catalog.sanitize_dataframe_columns_names(df=pd.DataFrame({'A': [1, 2], 'a': [3, 4], 'a_1': [5, 6]}), handle_duplicate_columns="rename").equals(pd.DataFrame({'a': [1, 2], 'a_1': [3, 4], 'a_1_1': [5, 6]}))
 
 
 def test_sanitize_names():

--- a/tests/test_athena.py
+++ b/tests/test_athena.py
@@ -247,7 +247,7 @@ def test_athena_read_list(glue_database):
 
 
 def test_sanitize_dataframe_column_names():
-    with pytest.warns(UserWarning, match=r"Some*"):
+    with pytest.warns(UserWarning, match=r"Duplicate*"):
         test_df = pd.DataFrame({"a": [1, 2], "b": [3, 4]})
         test_df.columns = ["a", "a"]
         assert wr.catalog.sanitize_dataframe_columns_names(df=pd.DataFrame({"A": [1, 2], "a": [3, 4]})).equals(test_df)


### PR DESCRIPTION
FIxes #1119 (hopefully)

I added: 
* One function `rename_duplicate_columns` which recursively appends `_n` to duplicated column names. 
* Added a flag to `sanitize_dataframe_columns_names` which can be `['warn', 'drop', 'rename']` will either leave the DF along, delete all but the first duplicated columns, or append a number to the duplicated column.
* Added some tests in `athena_test.py` to test this functionality. I'm not exactly sure this is the right place but other column sanitizers were there. 
* Exported `rename_duplicate_columns`
* Imported warnings.

I'm not sure if I followed how you handle warnings as I saw different syntax in other parts but it should be easy to modify if I was wrong. 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
