### PR TITLE
Use Amazon Lambda base images to build aws-data-wrangler

### DIFF
--- a/building/build-lambda-layers.sh
+++ b/building/build-lambda-layers.sh
@@ -17,7 +17,7 @@ docker run \
  --workdir /aws-data-wrangler/building/lambda \
  --rm \
  awswrangler-build-py36 \
- build-lambda-layer.sh "${VERSION}-py3.6" "ninja"
+ build-lambda-layer.sh "${VERSION}-py3.6" "ninja-build"
 
 # Python 3.7
 docker run \
@@ -25,7 +25,7 @@ docker run \
  --workdir /aws-data-wrangler/building/lambda \
  --rm \
  awswrangler-build-py37 \
- build-lambda-layer.sh "${VERSION}-py3.7" "ninja"
+ build-lambda-layer.sh "${VERSION}-py3.7" "ninja-build"
 
 # Python 3.8
 docker run \

--- a/building/lambda/Dockerfile
+++ b/building/lambda/Dockerfile
@@ -1,5 +1,4 @@
 ARG base_image
-ARG py_dev
 
 FROM ${base_image}
 
@@ -7,12 +6,16 @@ RUN yum install -y \
     boost-devel \
     jemalloc-devel \
     bison \
+    make \
+    gcc \
+    gcc-c++ \
     flex \
     autoconf \
-    ninja-build \
-    ${py_dev}
+    zip \
+    git \
+    ninja-build
 
-RUN pip3 install --upgrade pip six cython cmake hypothesis poetry
+RUN pip3 install --upgrade pip wheel && pip3 install --upgrade six cython cmake hypothesis poetry
 
 WORKDIR /root
 

--- a/building/lambda/Dockerfile
+++ b/building/lambda/Dockerfile
@@ -1,6 +1,7 @@
 ARG base_image
+ARG python_version=base
 
-FROM ${base_image}
+FROM ${base_image} AS base
 
 RUN yum install -y \
     boost-devel \
@@ -19,6 +20,13 @@ RUN pip3 install --upgrade pip wheel && pip3 install --upgrade six cython cmake 
 
 WORKDIR /root
 
+FROM base AS python36
+# only for python3.6
+RUN yum install -y python36-devel && \
+    mkdir -p /var/lang/include/ && \
+    ln -s /usr/include/python3.6m /var/lang/include/python3.6m
+
+FROM ${python_version}
 COPY pyproject.toml poetry.lock ./
 RUN poetry config virtualenvs.create false --local && poetry install --no-root
 

--- a/building/lambda/build-docker-images.sh
+++ b/building/lambda/build-docker-images.sh
@@ -9,23 +9,20 @@ docker build \
   --pull \
   --tag awswrangler-build-py36 \
   --build-arg base_image=lambci/lambda:build-python3.6 \
-  --build-arg py_dev=python36-devel \
   .
 
 # Python 3.7
 docker build \
   --pull \
   --tag awswrangler-build-py37 \
-  --build-arg base_image=lambci/lambda:build-python3.7 \
-  --build-arg py_dev=python37-devel \
+  --build-arg base_image=public.ecr.aws/lambda/python:3.7 \
   .
 
 # Python 3.8
 docker build \
   --pull \
   --tag awswrangler-build-py38 \
-  --build-arg base_image=lambci/lambda:build-python3.8 \
-  --build-arg py_dev=python38-devel \
+  --build-arg base_image=public.ecr.aws/lambda/python:3.8 \
   .
 
 rm -rf pyproject.toml poetry.lock

--- a/building/lambda/build-docker-images.sh
+++ b/building/lambda/build-docker-images.sh
@@ -4,11 +4,14 @@ set -ex
 cp ../../pyproject.toml .
 cp ../../poetry.lock .
 
+export DOCKER_BUILDKIT=1
+
 # Python 3.6
 docker build \
   --pull \
   --tag awswrangler-build-py36 \
-  --build-arg base_image=lambci/lambda:build-python3.6 \
+  --build-arg base_image=public.ecr.aws/lambda/python:3.6 \
+  --build-arg python_version=python36 \
   .
 
 # Python 3.7

--- a/building/lambda/build-lambda-layer.sh
+++ b/building/lambda/build-lambda-layer.sh
@@ -14,11 +14,12 @@ export ARROW_HOME=$(pwd)/dist
 export LD_LIBRARY_PATH=$(pwd)/dist/lib:$LD_LIBRARY_PATH
 
 git clone \
+  --depth 1 \
   --branch apache-arrow-6.0.0 \
   --single-branch \
   https://github.com/apache/arrow.git
 
-mkdir dist
+mkdir $ARROW_HOME
 mkdir arrow/cpp/build
 pushd arrow/cpp/build
 
@@ -58,18 +59,18 @@ export PYARROW_WITH_CUDA=0
 export PYARROW_WITH_PLASMA=0
 export PYARROW_WITH_PARQUET=1
 
-python setup.py build_ext \
+python3 setup.py build_ext \
   --build-type=release \
   --bundle-arrow-cpp \
   bdist_wheel
 
-pip install dist/pyarrow-*.whl -t /aws-data-wrangler/dist/pyarrow_files
+pip3 install dist/pyarrow-*.whl -t /aws-data-wrangler/dist/pyarrow_files
 
 popd
 
 pushd /aws-data-wrangler
 
-pip install . -t ./python
+pip3 install . -t ./python
 
 rm -rf python/pyarrow*
 rm -rf python/boto*


### PR DESCRIPTION
Subject: Use Amazon Lambda base images to build aws-data-wrangler

### Feature or Bugfix
- Feature

### Detail
- lambci/lambda while useful is a bit behind on python versions/architectures support (3.9, 3.10, arm64)
- and now Amazon provide base images that can be used for lambda, and are likely good for our use case too
- this PR is not adding 3.9/3.10/arm64 support, this would be covered in a different PR.

### Relates
- #1129

- By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
