### PR TITLE
Adding manifest parameter to 'redshift.copy_from_files' method

### DIFF
--- a/awswrangler/redshift.py
+++ b/awswrangler/redshift.py
@@ -1,6 +1,7 @@
 """Amazon Redshift Module."""
 # pylint: disable=too-many-lines
 
+import json
 import logging
 import uuid
 from typing import Any, Dict, Iterator, List, Optional, Tuple, Union
@@ -78,6 +79,14 @@ def _does_table_exist(cursor: redshift_connector.Cursor, schema: Optional[str], 
     return len(cursor.fetchall()) > 0
 
 
+def _get_paths_from_manifest(path: str, boto3_session: Optional[boto3.Session] = None) -> List[str]:
+    resource_s3: boto3.resource = _utils.resource(service_name="s3", session=boto3_session)
+    bucket, key = _utils.parse_path(path)
+    content_object = resource_s3.Object(bucket, key)
+    manifest_content = json.loads(content_object.get()["Body"].read().decode("utf-8"))
+    return [path["url"] for path in manifest_content["entries"]]
+
+
 def _make_s3_auth_string(
     aws_access_key_id: Optional[str] = None,
     aws_secret_access_key: Optional[str] = None,
@@ -120,7 +129,7 @@ def _copy(
     aws_session_token: Optional[str] = None,
     boto3_session: Optional[str] = None,
     schema: Optional[str] = None,
-    manifest: Optional[str] = None,
+    manifest: Optional[bool] = False,
 ) -> None:
     if schema is None:
         table_name: str = f'"{table}"'
@@ -136,9 +145,9 @@ def _copy(
     )
     ser_json_str: str = " SERIALIZETOJSON" if serialize_to_json else ""
     sql: str = (
-        f"COPY {table_name}\nFROM '{path}' {auth_str}\nFORMAT AS PARQUET{ser_json_str}"
-        if manifest is None
-        else f"COPY {table_name}\nFROM '{manifest}' {auth_str}\nFORMAT AS PARQUET{ser_json_str}\nMANIFEST"
+        f"COPY {table_name}\nFROM '{path}' {auth_str}\nFORMAT AS PARQUET{ser_json_str}\nMANIFEST"
+        if manifest
+        else f"COPY {table_name}\nFROM '{path}' {auth_str}\nFORMAT AS PARQUET{ser_json_str}"
     )
     _logger.debug("copy query:\n%s", sql)
     cursor.execute(sql)
@@ -226,7 +235,6 @@ def _redshift_types_from_path(
     athena_types, _ = s3.read_parquet_metadata(
         path=path,
         sampling=parquet_infer_sampling,
-        path_suffix=path_suffix,
         path_ignore_suffix=path_ignore_suffix,
         dataset=False,
         use_threads=use_threads,
@@ -262,6 +270,7 @@ def _create_table(  # pylint: disable=too-many-locals,too-many-arguments
     parquet_infer_sampling: float = 1.0,
     path_suffix: Optional[str] = None,
     path_ignore_suffix: Optional[str] = None,
+    manifest: Optional[bool] = False,
     use_threads: Union[bool, int] = True,
     boto3_session: Optional[boto3.Session] = None,
     s3_additional_kwargs: Optional[Dict[str, str]] = None,
@@ -307,6 +316,17 @@ def _create_table(  # pylint: disable=too-many-locals,too-many-arguments
             converter_func=_data_types.pyarrow2redshift,
         )
     elif path is not None:
+        if manifest:
+            if isinstance(path, str):
+                path = _get_paths_from_manifest(
+                    path=path,
+                    boto3_session=boto3_session,
+                )
+            else:
+                raise TypeError(
+                    f"""type: {type(path)} is not a valid type for 'path' when 'manifest' is set to True;
+                    must be a string"""
+                )
         redshift_types = _redshift_types_from_path(
             path=path,
             varchar_lengths_default=varchar_lengths_default,
@@ -1180,7 +1200,7 @@ def copy_from_files(  # pylint: disable=too-many-locals,too-many-arguments
     use_threads: Union[bool, int] = True,
     lock: bool = False,
     commit_transaction: bool = True,
-    manifest: Optional[str] = None,
+    manifest: Optional[bool] = False,
     boto3_session: Optional[boto3.Session] = None,
     s3_additional_kwargs: Optional[Dict[str, str]] = None,
 ) -> None:
@@ -1272,9 +1292,8 @@ def copy_from_files(  # pylint: disable=too-many-locals,too-many-arguments
         True to execute LOCK command inside the transaction to force serializable isolation.
     commit_transaction: bool
         Whether to commit the transaction. True by default.
-    manifest: str
-        Specifies the Amazon S3 object key for a manifest file that lists the data files to be loaded
-        (e.g. s3://bucket/prefix/)
+    manifest: bool
+        If set to true path argument accepts a S3 uri to a manifest file.
     boto3_session : boto3.Session(), optional
         Boto3 Session. The default boto3 session will be used if boto3_session receive None.
     s3_additional_kwargs:
@@ -1325,6 +1344,7 @@ def copy_from_files(  # pylint: disable=too-many-locals,too-many-arguments
                 varchar_lengths=varchar_lengths,
                 index=False,
                 dtype=None,
+                manifest=manifest,
                 use_threads=use_threads,
                 boto3_session=boto3_session,
                 s3_additional_kwargs=s3_additional_kwargs,

--- a/awswrangler/redshift.py
+++ b/awswrangler/redshift.py
@@ -79,12 +79,7 @@ def _does_table_exist(cursor: redshift_connector.Cursor, schema: Optional[str], 
     return len(cursor.fetchall()) > 0
 
 
-def _get_paths_from_manifest(path: Union[str, List[str]], boto3_session: Optional[boto3.Session] = None) -> List[str]:
-    if not isinstance(path, str):
-        raise TypeError(
-            f"""type: {type(path)} is not a valid type for 'path' when 'manifest' is set to True;
-            must be a string"""
-        )
+def _get_paths_from_manifest(path: str, boto3_session: Optional[boto3.Session] = None) -> List[str]:
     resource_s3: boto3.resource = _utils.resource(service_name="s3", session=boto3_session)
     bucket, key = _utils.parse_path(path)
     content_object = resource_s3.Object(bucket, key)
@@ -321,6 +316,11 @@ def _create_table(  # pylint: disable=too-many-locals,too-many-arguments
         )
     elif path is not None:
         if manifest:
+            if not isinstance(path, str):
+                raise TypeError(
+                    f"""type: {type(path)} is not a valid type for 'path' when 'manifest' is set to True;
+                    must be a string"""
+                )
             path = _get_paths_from_manifest(
                 path=path,
                 boto3_session=boto3_session,

--- a/awswrangler/redshift.py
+++ b/awswrangler/redshift.py
@@ -138,7 +138,7 @@ def _copy(
     sql: str = (
         f"COPY {table_name}\nFROM '{path}' {auth_str}\nFORMAT AS PARQUET{ser_json_str}"
         if manifest is None
-        else f"COPY {table_name}\nFROM '{manifest}' {auth_str}\nMANIFEST\nFORMAT AS PARQUET{ser_json_str}"
+        else f"COPY {table_name}\nFROM '{manifest}' {auth_str}\nFORMAT AS PARQUET{ser_json_str}\nMANIFEST"
     )
     _logger.debug("copy query:\n%s", sql)
     cursor.execute(sql)

--- a/awswrangler/redshift.py
+++ b/awswrangler/redshift.py
@@ -235,6 +235,7 @@ def _redshift_types_from_path(
     athena_types, _ = s3.read_parquet_metadata(
         path=path,
         sampling=parquet_infer_sampling,
+        path_suffix=path_suffix,
         path_ignore_suffix=path_ignore_suffix,
         dataset=False,
         use_threads=use_threads,

--- a/test_infra/poetry.lock
+++ b/test_infra/poetry.lock
@@ -1,652 +1,670 @@
 [[package]]
 name = "attrs"
-version = "21.2.0"
+version = "21.4.0"
 description = "Classes Without Boilerplate"
 category = "main"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [package.extras]
-dev = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins", "zope.interface", "furo", "sphinx", "sphinx-notfound-page", "pre-commit"]
+dev = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins", "zope.interface", "furo", "sphinx", "sphinx-notfound-page", "pre-commit", "cloudpickle"]
 docs = ["furo", "sphinx", "zope.interface", "sphinx-notfound-page"]
-tests = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins", "zope.interface"]
-tests_no_zope = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins"]
+tests = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins", "zope.interface", "cloudpickle"]
+tests_no_zope = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins", "cloudpickle"]
 
 [[package]]
 name = "aws-cdk.assets"
-version = "1.130.0"
+version = "1.143.0"
 description = "This module is deprecated. All types are now available under the core module"
 category = "main"
 optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
-"aws-cdk.core" = "1.130.0"
-"aws-cdk.cx-api" = "1.130.0"
+"aws-cdk.core" = "1.143.0"
+"aws-cdk.cx-api" = "1.143.0"
 constructs = ">=3.3.69,<4.0.0"
-jsii = ">=1.41.0,<2.0.0"
+jsii = ">=1.52.1,<2.0.0"
+publication = ">=0.0.3"
+
+[[package]]
+name = "aws-cdk.aws-acmpca"
+version = "1.143.0"
+description = "The CDK Construct Library for AWS::ACMPCA"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+"aws-cdk.core" = "1.143.0"
+constructs = ">=3.3.69,<4.0.0"
+jsii = ">=1.52.1,<2.0.0"
 publication = ">=0.0.3"
 
 [[package]]
 name = "aws-cdk.aws-applicationautoscaling"
-version = "1.130.0"
+version = "1.143.0"
 description = "The CDK Construct Library for AWS::ApplicationAutoScaling"
 category = "main"
 optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
-"aws-cdk.aws-autoscaling-common" = "1.130.0"
-"aws-cdk.aws-cloudwatch" = "1.130.0"
-"aws-cdk.aws-iam" = "1.130.0"
-"aws-cdk.core" = "1.130.0"
+"aws-cdk.aws-autoscaling-common" = "1.143.0"
+"aws-cdk.aws-cloudwatch" = "1.143.0"
+"aws-cdk.aws-iam" = "1.143.0"
+"aws-cdk.core" = "1.143.0"
 constructs = ">=3.3.69,<4.0.0"
-jsii = ">=1.41.0,<2.0.0"
+jsii = ">=1.52.1,<2.0.0"
 publication = ">=0.0.3"
 
 [[package]]
 name = "aws-cdk.aws-autoscaling-common"
-version = "1.130.0"
+version = "1.143.0"
 description = "Common implementation package for @aws-cdk/aws-autoscaling and @aws-cdk/aws-applicationautoscaling"
 category = "main"
 optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
-"aws-cdk.aws-iam" = "1.130.0"
-"aws-cdk.core" = "1.130.0"
+"aws-cdk.aws-iam" = "1.143.0"
+"aws-cdk.core" = "1.143.0"
 constructs = ">=3.3.69,<4.0.0"
-jsii = ">=1.41.0,<2.0.0"
+jsii = ">=1.52.1,<2.0.0"
 publication = ">=0.0.3"
 
 [[package]]
 name = "aws-cdk.aws-certificatemanager"
-version = "1.130.0"
+version = "1.143.0"
 description = "The CDK Construct Library for AWS::CertificateManager"
 category = "main"
 optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
-"aws-cdk.aws-cloudwatch" = "1.130.0"
-"aws-cdk.aws-iam" = "1.130.0"
-"aws-cdk.aws-lambda" = "1.130.0"
-"aws-cdk.aws-route53" = "1.130.0"
-"aws-cdk.core" = "1.130.0"
+"aws-cdk.aws-acmpca" = "1.143.0"
+"aws-cdk.aws-cloudwatch" = "1.143.0"
+"aws-cdk.aws-iam" = "1.143.0"
+"aws-cdk.aws-lambda" = "1.143.0"
+"aws-cdk.aws-route53" = "1.143.0"
+"aws-cdk.core" = "1.143.0"
 constructs = ">=3.3.69,<4.0.0"
-jsii = ">=1.41.0,<2.0.0"
+jsii = ">=1.52.1,<2.0.0"
 publication = ">=0.0.3"
 
 [[package]]
 name = "aws-cdk.aws-cloudformation"
-version = "1.130.0"
+version = "1.143.0"
 description = "The CDK Construct Library for AWS::CloudFormation"
 category = "main"
 optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
-"aws-cdk.aws-iam" = "1.130.0"
-"aws-cdk.aws-lambda" = "1.130.0"
-"aws-cdk.aws-s3" = "1.130.0"
-"aws-cdk.aws-sns" = "1.130.0"
-"aws-cdk.core" = "1.130.0"
-"aws-cdk.cx-api" = "1.130.0"
+"aws-cdk.aws-iam" = "1.143.0"
+"aws-cdk.aws-lambda" = "1.143.0"
+"aws-cdk.aws-s3" = "1.143.0"
+"aws-cdk.aws-sns" = "1.143.0"
+"aws-cdk.core" = "1.143.0"
+"aws-cdk.cx-api" = "1.143.0"
 constructs = ">=3.3.69,<4.0.0"
-jsii = ">=1.41.0,<2.0.0"
+jsii = ">=1.52.1,<2.0.0"
 publication = ">=0.0.3"
 
 [[package]]
 name = "aws-cdk.aws-cloudwatch"
-version = "1.130.0"
+version = "1.143.0"
 description = "The CDK Construct Library for AWS::CloudWatch"
 category = "main"
 optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
-"aws-cdk.aws-iam" = "1.130.0"
-"aws-cdk.core" = "1.130.0"
+"aws-cdk.aws-iam" = "1.143.0"
+"aws-cdk.core" = "1.143.0"
 constructs = ">=3.3.69,<4.0.0"
-jsii = ">=1.41.0,<2.0.0"
+jsii = ">=1.52.1,<2.0.0"
 publication = ">=0.0.3"
 
 [[package]]
 name = "aws-cdk.aws-codeguruprofiler"
-version = "1.130.0"
+version = "1.143.0"
 description = "The CDK Construct Library for AWS::CodeGuruProfiler"
 category = "main"
 optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
-"aws-cdk.aws-iam" = "1.130.0"
-"aws-cdk.core" = "1.130.0"
+"aws-cdk.aws-iam" = "1.143.0"
+"aws-cdk.core" = "1.143.0"
 constructs = ">=3.3.69,<4.0.0"
-jsii = ">=1.41.0,<2.0.0"
+jsii = ">=1.52.1,<2.0.0"
 publication = ">=0.0.3"
 
 [[package]]
 name = "aws-cdk.aws-codestarnotifications"
-version = "1.130.0"
+version = "1.143.0"
 description = "The CDK Construct Library for AWS::CodeStarNotifications"
 category = "main"
 optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
-"aws-cdk.core" = "1.130.0"
+"aws-cdk.core" = "1.143.0"
 constructs = ">=3.3.69,<4.0.0"
-jsii = ">=1.41.0,<2.0.0"
+jsii = ">=1.52.1,<2.0.0"
 publication = ">=0.0.3"
 
 [[package]]
 name = "aws-cdk.aws-ec2"
-version = "1.130.0"
+version = "1.143.0"
 description = "The CDK Construct Library for AWS::EC2"
 category = "main"
 optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
-"aws-cdk.aws-cloudwatch" = "1.130.0"
-"aws-cdk.aws-iam" = "1.130.0"
-"aws-cdk.aws-kms" = "1.130.0"
-"aws-cdk.aws-logs" = "1.130.0"
-"aws-cdk.aws-s3" = "1.130.0"
-"aws-cdk.aws-s3-assets" = "1.130.0"
-"aws-cdk.aws-ssm" = "1.130.0"
-"aws-cdk.cloud-assembly-schema" = "1.130.0"
-"aws-cdk.core" = "1.130.0"
-"aws-cdk.cx-api" = "1.130.0"
-"aws-cdk.region-info" = "1.130.0"
+"aws-cdk.aws-cloudwatch" = "1.143.0"
+"aws-cdk.aws-iam" = "1.143.0"
+"aws-cdk.aws-kms" = "1.143.0"
+"aws-cdk.aws-logs" = "1.143.0"
+"aws-cdk.aws-s3" = "1.143.0"
+"aws-cdk.aws-s3-assets" = "1.143.0"
+"aws-cdk.aws-ssm" = "1.143.0"
+"aws-cdk.cloud-assembly-schema" = "1.143.0"
+"aws-cdk.core" = "1.143.0"
+"aws-cdk.cx-api" = "1.143.0"
+"aws-cdk.region-info" = "1.143.0"
 constructs = ">=3.3.69,<4.0.0"
-jsii = ">=1.41.0,<2.0.0"
+jsii = ">=1.52.1,<2.0.0"
 publication = ">=0.0.3"
 
 [[package]]
 name = "aws-cdk.aws-ecr"
-version = "1.130.0"
+version = "1.143.0"
 description = "The CDK Construct Library for AWS::ECR"
 category = "main"
 optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
-"aws-cdk.aws-events" = "1.130.0"
-"aws-cdk.aws-iam" = "1.130.0"
-"aws-cdk.core" = "1.130.0"
+"aws-cdk.aws-events" = "1.143.0"
+"aws-cdk.aws-iam" = "1.143.0"
+"aws-cdk.aws-kms" = "1.143.0"
+"aws-cdk.core" = "1.143.0"
 constructs = ">=3.3.69,<4.0.0"
-jsii = ">=1.41.0,<2.0.0"
+jsii = ">=1.52.1,<2.0.0"
 publication = ">=0.0.3"
 
 [[package]]
 name = "aws-cdk.aws-ecr-assets"
-version = "1.130.0"
+version = "1.143.0"
 description = "Docker image assets deployed to ECR"
 category = "main"
 optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
-"aws-cdk.assets" = "1.130.0"
-"aws-cdk.aws-ecr" = "1.130.0"
-"aws-cdk.aws-iam" = "1.130.0"
-"aws-cdk.aws-s3" = "1.130.0"
-"aws-cdk.core" = "1.130.0"
-"aws-cdk.cx-api" = "1.130.0"
+"aws-cdk.assets" = "1.143.0"
+"aws-cdk.aws-ecr" = "1.143.0"
+"aws-cdk.aws-iam" = "1.143.0"
+"aws-cdk.aws-s3" = "1.143.0"
+"aws-cdk.core" = "1.143.0"
+"aws-cdk.cx-api" = "1.143.0"
 constructs = ">=3.3.69,<4.0.0"
-jsii = ">=1.41.0,<2.0.0"
+jsii = ">=1.52.1,<2.0.0"
 publication = ">=0.0.3"
 
 [[package]]
 name = "aws-cdk.aws-efs"
-version = "1.130.0"
+version = "1.143.0"
 description = "The CDK Construct Library for AWS::EFS"
 category = "main"
 optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
-"aws-cdk.aws-ec2" = "1.130.0"
-"aws-cdk.aws-iam" = "1.130.0"
-"aws-cdk.aws-kms" = "1.130.0"
-"aws-cdk.cloud-assembly-schema" = "1.130.0"
-"aws-cdk.core" = "1.130.0"
-"aws-cdk.cx-api" = "1.130.0"
+"aws-cdk.aws-ec2" = "1.143.0"
+"aws-cdk.aws-iam" = "1.143.0"
+"aws-cdk.aws-kms" = "1.143.0"
+"aws-cdk.cloud-assembly-schema" = "1.143.0"
+"aws-cdk.core" = "1.143.0"
+"aws-cdk.cx-api" = "1.143.0"
 constructs = ">=3.3.69,<4.0.0"
-jsii = ">=1.41.0,<2.0.0"
+jsii = ">=1.52.1,<2.0.0"
 publication = ">=0.0.3"
 
 [[package]]
 name = "aws-cdk.aws-events"
-version = "1.130.0"
+version = "1.143.0"
 description = "Amazon EventBridge Construct Library"
 category = "main"
 optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
-"aws-cdk.aws-iam" = "1.130.0"
-"aws-cdk.core" = "1.130.0"
+"aws-cdk.aws-iam" = "1.143.0"
+"aws-cdk.core" = "1.143.0"
 constructs = ">=3.3.69,<4.0.0"
-jsii = ">=1.41.0,<2.0.0"
+jsii = ">=1.52.1,<2.0.0"
 publication = ">=0.0.3"
 
 [[package]]
 name = "aws-cdk.aws-glue"
-version = "1.130.0"
+version = "1.143.0"
 description = "The CDK Construct Library for AWS::Glue"
 category = "main"
 optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
-"aws-cdk.assets" = "1.130.0"
-"aws-cdk.aws-cloudwatch" = "1.130.0"
-"aws-cdk.aws-ec2" = "1.130.0"
-"aws-cdk.aws-events" = "1.130.0"
-"aws-cdk.aws-iam" = "1.130.0"
-"aws-cdk.aws-kms" = "1.130.0"
-"aws-cdk.aws-logs" = "1.130.0"
-"aws-cdk.aws-s3" = "1.130.0"
-"aws-cdk.aws-s3-assets" = "1.130.0"
-"aws-cdk.core" = "1.130.0"
+"aws-cdk.assets" = "1.143.0"
+"aws-cdk.aws-cloudwatch" = "1.143.0"
+"aws-cdk.aws-ec2" = "1.143.0"
+"aws-cdk.aws-events" = "1.143.0"
+"aws-cdk.aws-iam" = "1.143.0"
+"aws-cdk.aws-kms" = "1.143.0"
+"aws-cdk.aws-logs" = "1.143.0"
+"aws-cdk.aws-s3" = "1.143.0"
+"aws-cdk.aws-s3-assets" = "1.143.0"
+"aws-cdk.core" = "1.143.0"
+"aws-cdk.custom-resources" = "1.143.0"
 constructs = ">=3.3.69,<4.0.0"
-jsii = ">=1.41.0,<2.0.0"
+jsii = ">=1.52.1,<2.0.0"
 publication = ">=0.0.3"
 
 [[package]]
 name = "aws-cdk.aws-iam"
-version = "1.130.0"
+version = "1.143.0"
 description = "CDK routines for easily assigning correct and minimal IAM permissions"
 category = "main"
 optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
-"aws-cdk.core" = "1.130.0"
-"aws-cdk.region-info" = "1.130.0"
+"aws-cdk.core" = "1.143.0"
+"aws-cdk.region-info" = "1.143.0"
 constructs = ">=3.3.69,<4.0.0"
-jsii = ">=1.41.0,<2.0.0"
+jsii = ">=1.52.1,<2.0.0"
 publication = ">=0.0.3"
 
 [[package]]
 name = "aws-cdk.aws-kms"
-version = "1.130.0"
+version = "1.143.0"
 description = "The CDK Construct Library for AWS::KMS"
 category = "main"
 optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
-"aws-cdk.aws-iam" = "1.130.0"
-"aws-cdk.cloud-assembly-schema" = "1.130.0"
-"aws-cdk.core" = "1.130.0"
-"aws-cdk.cx-api" = "1.130.0"
+"aws-cdk.aws-iam" = "1.143.0"
+"aws-cdk.cloud-assembly-schema" = "1.143.0"
+"aws-cdk.core" = "1.143.0"
+"aws-cdk.cx-api" = "1.143.0"
 constructs = ">=3.3.69,<4.0.0"
-jsii = ">=1.41.0,<2.0.0"
+jsii = ">=1.52.1,<2.0.0"
 publication = ">=0.0.3"
 
 [[package]]
 name = "aws-cdk.aws-lakeformation"
-version = "1.130.0"
+version = "1.143.0"
 description = "The CDK Construct Library for AWS::LakeFormation"
 category = "main"
 optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
-"aws-cdk.core" = "1.130.0"
+"aws-cdk.core" = "1.143.0"
 constructs = ">=3.3.69,<4.0.0"
-jsii = ">=1.41.0,<2.0.0"
+jsii = ">=1.52.1,<2.0.0"
 publication = ">=0.0.3"
 
 [[package]]
 name = "aws-cdk.aws-lambda"
-version = "1.130.0"
+version = "1.143.0"
 description = "The CDK Construct Library for AWS::Lambda"
 category = "main"
 optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
-"aws-cdk.aws-applicationautoscaling" = "1.130.0"
-"aws-cdk.aws-cloudwatch" = "1.130.0"
-"aws-cdk.aws-codeguruprofiler" = "1.130.0"
-"aws-cdk.aws-ec2" = "1.130.0"
-"aws-cdk.aws-ecr" = "1.130.0"
-"aws-cdk.aws-ecr-assets" = "1.130.0"
-"aws-cdk.aws-efs" = "1.130.0"
-"aws-cdk.aws-events" = "1.130.0"
-"aws-cdk.aws-iam" = "1.130.0"
-"aws-cdk.aws-kms" = "1.130.0"
-"aws-cdk.aws-logs" = "1.130.0"
-"aws-cdk.aws-s3" = "1.130.0"
-"aws-cdk.aws-s3-assets" = "1.130.0"
-"aws-cdk.aws-signer" = "1.130.0"
-"aws-cdk.aws-sqs" = "1.130.0"
-"aws-cdk.core" = "1.130.0"
-"aws-cdk.cx-api" = "1.130.0"
-"aws-cdk.region-info" = "1.130.0"
+"aws-cdk.aws-applicationautoscaling" = "1.143.0"
+"aws-cdk.aws-cloudwatch" = "1.143.0"
+"aws-cdk.aws-codeguruprofiler" = "1.143.0"
+"aws-cdk.aws-ec2" = "1.143.0"
+"aws-cdk.aws-ecr" = "1.143.0"
+"aws-cdk.aws-ecr-assets" = "1.143.0"
+"aws-cdk.aws-efs" = "1.143.0"
+"aws-cdk.aws-events" = "1.143.0"
+"aws-cdk.aws-iam" = "1.143.0"
+"aws-cdk.aws-kms" = "1.143.0"
+"aws-cdk.aws-logs" = "1.143.0"
+"aws-cdk.aws-s3" = "1.143.0"
+"aws-cdk.aws-s3-assets" = "1.143.0"
+"aws-cdk.aws-signer" = "1.143.0"
+"aws-cdk.aws-sqs" = "1.143.0"
+"aws-cdk.core" = "1.143.0"
+"aws-cdk.cx-api" = "1.143.0"
+"aws-cdk.region-info" = "1.143.0"
 constructs = ">=3.3.69,<4.0.0"
-jsii = ">=1.41.0,<2.0.0"
+jsii = ">=1.52.1,<2.0.0"
 publication = ">=0.0.3"
 
 [[package]]
 name = "aws-cdk.aws-logs"
-version = "1.130.0"
+version = "1.143.0"
 description = "The CDK Construct Library for AWS::Logs"
 category = "main"
 optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
-"aws-cdk.aws-cloudwatch" = "1.130.0"
-"aws-cdk.aws-iam" = "1.130.0"
-"aws-cdk.aws-kms" = "1.130.0"
-"aws-cdk.aws-s3-assets" = "1.130.0"
-"aws-cdk.core" = "1.130.0"
+"aws-cdk.aws-cloudwatch" = "1.143.0"
+"aws-cdk.aws-iam" = "1.143.0"
+"aws-cdk.aws-kms" = "1.143.0"
+"aws-cdk.aws-s3-assets" = "1.143.0"
+"aws-cdk.core" = "1.143.0"
+"aws-cdk.cx-api" = "1.143.0"
 constructs = ">=3.3.69,<4.0.0"
-jsii = ">=1.41.0,<2.0.0"
+jsii = ">=1.52.1,<2.0.0"
 publication = ">=0.0.3"
 
 [[package]]
 name = "aws-cdk.aws-opensearchservice"
-version = "1.130.0"
+version = "1.143.0"
 description = "The CDK Construct Library for AWS::OpenSearchService"
 category = "main"
 optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
-"aws-cdk.aws-certificatemanager" = "1.130.0"
-"aws-cdk.aws-cloudwatch" = "1.130.0"
-"aws-cdk.aws-ec2" = "1.130.0"
-"aws-cdk.aws-iam" = "1.130.0"
-"aws-cdk.aws-kms" = "1.130.0"
-"aws-cdk.aws-logs" = "1.130.0"
-"aws-cdk.aws-route53" = "1.130.0"
-"aws-cdk.aws-secretsmanager" = "1.130.0"
-"aws-cdk.core" = "1.130.0"
-"aws-cdk.custom-resources" = "1.130.0"
+"aws-cdk.aws-certificatemanager" = "1.143.0"
+"aws-cdk.aws-cloudwatch" = "1.143.0"
+"aws-cdk.aws-ec2" = "1.143.0"
+"aws-cdk.aws-iam" = "1.143.0"
+"aws-cdk.aws-kms" = "1.143.0"
+"aws-cdk.aws-logs" = "1.143.0"
+"aws-cdk.aws-route53" = "1.143.0"
+"aws-cdk.aws-secretsmanager" = "1.143.0"
+"aws-cdk.core" = "1.143.0"
+"aws-cdk.custom-resources" = "1.143.0"
 constructs = ">=3.3.69,<4.0.0"
-jsii = ">=1.41.0,<2.0.0"
+jsii = ">=1.52.1,<2.0.0"
 publication = ">=0.0.3"
 
 [[package]]
 name = "aws-cdk.aws-rds"
-version = "1.130.0"
+version = "1.143.0"
 description = "The CDK Construct Library for AWS::RDS"
 category = "main"
 optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
-"aws-cdk.aws-cloudwatch" = "1.130.0"
-"aws-cdk.aws-ec2" = "1.130.0"
-"aws-cdk.aws-events" = "1.130.0"
-"aws-cdk.aws-iam" = "1.130.0"
-"aws-cdk.aws-kms" = "1.130.0"
-"aws-cdk.aws-logs" = "1.130.0"
-"aws-cdk.aws-s3" = "1.130.0"
-"aws-cdk.aws-secretsmanager" = "1.130.0"
-"aws-cdk.core" = "1.130.0"
-"aws-cdk.cx-api" = "1.130.0"
+"aws-cdk.aws-cloudwatch" = "1.143.0"
+"aws-cdk.aws-ec2" = "1.143.0"
+"aws-cdk.aws-events" = "1.143.0"
+"aws-cdk.aws-iam" = "1.143.0"
+"aws-cdk.aws-kms" = "1.143.0"
+"aws-cdk.aws-logs" = "1.143.0"
+"aws-cdk.aws-s3" = "1.143.0"
+"aws-cdk.aws-secretsmanager" = "1.143.0"
+"aws-cdk.core" = "1.143.0"
+"aws-cdk.cx-api" = "1.143.0"
 constructs = ">=3.3.69,<4.0.0"
-jsii = ">=1.41.0,<2.0.0"
+jsii = ">=1.52.1,<2.0.0"
 publication = ">=0.0.3"
 
 [[package]]
 name = "aws-cdk.aws-redshift"
-version = "1.130.0"
+version = "1.143.0"
 description = "The CDK Construct Library for AWS::Redshift"
 category = "main"
 optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
-"aws-cdk.aws-ec2" = "1.130.0"
-"aws-cdk.aws-iam" = "1.130.0"
-"aws-cdk.aws-kms" = "1.130.0"
-"aws-cdk.aws-lambda" = "1.130.0"
-"aws-cdk.aws-s3" = "1.130.0"
-"aws-cdk.aws-secretsmanager" = "1.130.0"
-"aws-cdk.core" = "1.130.0"
-"aws-cdk.custom-resources" = "1.130.0"
+"aws-cdk.aws-ec2" = "1.143.0"
+"aws-cdk.aws-iam" = "1.143.0"
+"aws-cdk.aws-kms" = "1.143.0"
+"aws-cdk.aws-lambda" = "1.143.0"
+"aws-cdk.aws-s3" = "1.143.0"
+"aws-cdk.aws-secretsmanager" = "1.143.0"
+"aws-cdk.core" = "1.143.0"
+"aws-cdk.custom-resources" = "1.143.0"
 constructs = ">=3.3.69,<4.0.0"
-jsii = ">=1.41.0,<2.0.0"
+jsii = ">=1.52.1,<2.0.0"
 publication = ">=0.0.3"
 
 [[package]]
 name = "aws-cdk.aws-route53"
-version = "1.130.0"
+version = "1.143.0"
 description = "The CDK Construct Library for AWS::Route53"
 category = "main"
 optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
-"aws-cdk.aws-ec2" = "1.130.0"
-"aws-cdk.aws-iam" = "1.130.0"
-"aws-cdk.aws-logs" = "1.130.0"
-"aws-cdk.cloud-assembly-schema" = "1.130.0"
-"aws-cdk.core" = "1.130.0"
-"aws-cdk.custom-resources" = "1.130.0"
+"aws-cdk.aws-ec2" = "1.143.0"
+"aws-cdk.aws-iam" = "1.143.0"
+"aws-cdk.aws-logs" = "1.143.0"
+"aws-cdk.cloud-assembly-schema" = "1.143.0"
+"aws-cdk.core" = "1.143.0"
+"aws-cdk.custom-resources" = "1.143.0"
 constructs = ">=3.3.69,<4.0.0"
-jsii = ">=1.41.0,<2.0.0"
+jsii = ">=1.52.1,<2.0.0"
 publication = ">=0.0.3"
 
 [[package]]
 name = "aws-cdk.aws-s3"
-version = "1.130.0"
+version = "1.143.0"
 description = "The CDK Construct Library for AWS::S3"
 category = "main"
 optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
-"aws-cdk.aws-events" = "1.130.0"
-"aws-cdk.aws-iam" = "1.130.0"
-"aws-cdk.aws-kms" = "1.130.0"
-"aws-cdk.core" = "1.130.0"
-"aws-cdk.cx-api" = "1.130.0"
+"aws-cdk.aws-events" = "1.143.0"
+"aws-cdk.aws-iam" = "1.143.0"
+"aws-cdk.aws-kms" = "1.143.0"
+"aws-cdk.core" = "1.143.0"
+"aws-cdk.cx-api" = "1.143.0"
 constructs = ">=3.3.69,<4.0.0"
-jsii = ">=1.41.0,<2.0.0"
+jsii = ">=1.52.1,<2.0.0"
 publication = ">=0.0.3"
 
 [[package]]
 name = "aws-cdk.aws-s3-assets"
-version = "1.130.0"
+version = "1.143.0"
 description = "Deploy local files and directories to S3"
 category = "main"
 optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
-"aws-cdk.assets" = "1.130.0"
-"aws-cdk.aws-iam" = "1.130.0"
-"aws-cdk.aws-kms" = "1.130.0"
-"aws-cdk.aws-s3" = "1.130.0"
-"aws-cdk.core" = "1.130.0"
-"aws-cdk.cx-api" = "1.130.0"
+"aws-cdk.assets" = "1.143.0"
+"aws-cdk.aws-iam" = "1.143.0"
+"aws-cdk.aws-kms" = "1.143.0"
+"aws-cdk.aws-s3" = "1.143.0"
+"aws-cdk.core" = "1.143.0"
+"aws-cdk.cx-api" = "1.143.0"
 constructs = ">=3.3.69,<4.0.0"
-jsii = ">=1.41.0,<2.0.0"
+jsii = ">=1.52.1,<2.0.0"
 publication = ">=0.0.3"
 
 [[package]]
 name = "aws-cdk.aws-sam"
-version = "1.130.0"
+version = "1.143.0"
 description = "The CDK Construct Library for the AWS Serverless Application Model (SAM) resources"
 category = "main"
 optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
-"aws-cdk.core" = "1.130.0"
+"aws-cdk.core" = "1.143.0"
 constructs = ">=3.3.69,<4.0.0"
-jsii = ">=1.41.0,<2.0.0"
+jsii = ">=1.52.1,<2.0.0"
 publication = ">=0.0.3"
 
 [[package]]
 name = "aws-cdk.aws-secretsmanager"
-version = "1.130.0"
+version = "1.143.0"
 description = "The CDK Construct Library for AWS::SecretsManager"
 category = "main"
 optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
-"aws-cdk.aws-ec2" = "1.130.0"
-"aws-cdk.aws-iam" = "1.130.0"
-"aws-cdk.aws-kms" = "1.130.0"
-"aws-cdk.aws-lambda" = "1.130.0"
-"aws-cdk.aws-sam" = "1.130.0"
-"aws-cdk.core" = "1.130.0"
-"aws-cdk.cx-api" = "1.130.0"
+"aws-cdk.aws-ec2" = "1.143.0"
+"aws-cdk.aws-iam" = "1.143.0"
+"aws-cdk.aws-kms" = "1.143.0"
+"aws-cdk.aws-lambda" = "1.143.0"
+"aws-cdk.aws-sam" = "1.143.0"
+"aws-cdk.core" = "1.143.0"
+"aws-cdk.cx-api" = "1.143.0"
 constructs = ">=3.3.69,<4.0.0"
-jsii = ">=1.41.0,<2.0.0"
+jsii = ">=1.52.1,<2.0.0"
 publication = ">=0.0.3"
 
 [[package]]
 name = "aws-cdk.aws-signer"
-version = "1.130.0"
+version = "1.143.0"
 description = "The CDK Construct Library for AWS::Signer"
 category = "main"
 optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
-"aws-cdk.core" = "1.130.0"
+"aws-cdk.core" = "1.143.0"
 constructs = ">=3.3.69,<4.0.0"
-jsii = ">=1.41.0,<2.0.0"
+jsii = ">=1.52.1,<2.0.0"
 publication = ">=0.0.3"
 
 [[package]]
 name = "aws-cdk.aws-sns"
-version = "1.130.0"
+version = "1.143.0"
 description = "The CDK Construct Library for AWS::SNS"
 category = "main"
 optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
-"aws-cdk.aws-cloudwatch" = "1.130.0"
-"aws-cdk.aws-codestarnotifications" = "1.130.0"
-"aws-cdk.aws-events" = "1.130.0"
-"aws-cdk.aws-iam" = "1.130.0"
-"aws-cdk.aws-kms" = "1.130.0"
-"aws-cdk.aws-sqs" = "1.130.0"
-"aws-cdk.core" = "1.130.0"
+"aws-cdk.aws-cloudwatch" = "1.143.0"
+"aws-cdk.aws-codestarnotifications" = "1.143.0"
+"aws-cdk.aws-events" = "1.143.0"
+"aws-cdk.aws-iam" = "1.143.0"
+"aws-cdk.aws-kms" = "1.143.0"
+"aws-cdk.aws-sqs" = "1.143.0"
+"aws-cdk.core" = "1.143.0"
 constructs = ">=3.3.69,<4.0.0"
-jsii = ">=1.41.0,<2.0.0"
+jsii = ">=1.52.1,<2.0.0"
 publication = ">=0.0.3"
 
 [[package]]
 name = "aws-cdk.aws-sqs"
-version = "1.130.0"
+version = "1.143.0"
 description = "The CDK Construct Library for AWS::SQS"
 category = "main"
 optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
-"aws-cdk.aws-cloudwatch" = "1.130.0"
-"aws-cdk.aws-iam" = "1.130.0"
-"aws-cdk.aws-kms" = "1.130.0"
-"aws-cdk.core" = "1.130.0"
+"aws-cdk.aws-cloudwatch" = "1.143.0"
+"aws-cdk.aws-iam" = "1.143.0"
+"aws-cdk.aws-kms" = "1.143.0"
+"aws-cdk.core" = "1.143.0"
 constructs = ">=3.3.69,<4.0.0"
-jsii = ">=1.41.0,<2.0.0"
+jsii = ">=1.52.1,<2.0.0"
 publication = ">=0.0.3"
 
 [[package]]
 name = "aws-cdk.aws-ssm"
-version = "1.130.0"
+version = "1.143.0"
 description = "The CDK Construct Library for AWS::SSM"
 category = "main"
 optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
-"aws-cdk.aws-iam" = "1.130.0"
-"aws-cdk.aws-kms" = "1.130.0"
-"aws-cdk.cloud-assembly-schema" = "1.130.0"
-"aws-cdk.core" = "1.130.0"
+"aws-cdk.aws-iam" = "1.143.0"
+"aws-cdk.aws-kms" = "1.143.0"
+"aws-cdk.cloud-assembly-schema" = "1.143.0"
+"aws-cdk.core" = "1.143.0"
 constructs = ">=3.3.69,<4.0.0"
-jsii = ">=1.41.0,<2.0.0"
+jsii = ">=1.52.1,<2.0.0"
 publication = ">=0.0.3"
 
 [[package]]
 name = "aws-cdk.cloud-assembly-schema"
-version = "1.130.0"
+version = "1.143.0"
 description = "Cloud Assembly Schema"
 category = "main"
 optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
-jsii = ">=1.41.0,<2.0.0"
+jsii = ">=1.52.1,<2.0.0"
 publication = ">=0.0.3"
 
 [[package]]
 name = "aws-cdk.core"
-version = "1.130.0"
+version = "1.143.0"
 description = "AWS Cloud Development Kit Core Library"
 category = "main"
 optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
-"aws-cdk.cloud-assembly-schema" = "1.130.0"
-"aws-cdk.cx-api" = "1.130.0"
-"aws-cdk.region-info" = "1.130.0"
+"aws-cdk.cloud-assembly-schema" = "1.143.0"
+"aws-cdk.cx-api" = "1.143.0"
+"aws-cdk.region-info" = "1.143.0"
 constructs = ">=3.3.69,<4.0.0"
-jsii = ">=1.41.0,<2.0.0"
+jsii = ">=1.52.1,<2.0.0"
 publication = ">=0.0.3"
 
 [[package]]
 name = "aws-cdk.custom-resources"
-version = "1.130.0"
+version = "1.143.0"
 description = "Constructs for implementing CDK custom resources"
 category = "main"
 optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
-"aws-cdk.aws-cloudformation" = "1.130.0"
-"aws-cdk.aws-ec2" = "1.130.0"
-"aws-cdk.aws-iam" = "1.130.0"
-"aws-cdk.aws-lambda" = "1.130.0"
-"aws-cdk.aws-logs" = "1.130.0"
-"aws-cdk.aws-sns" = "1.130.0"
-"aws-cdk.core" = "1.130.0"
+"aws-cdk.aws-cloudformation" = "1.143.0"
+"aws-cdk.aws-ec2" = "1.143.0"
+"aws-cdk.aws-iam" = "1.143.0"
+"aws-cdk.aws-lambda" = "1.143.0"
+"aws-cdk.aws-logs" = "1.143.0"
+"aws-cdk.aws-sns" = "1.143.0"
+"aws-cdk.core" = "1.143.0"
 constructs = ">=3.3.69,<4.0.0"
-jsii = ">=1.41.0,<2.0.0"
+jsii = ">=1.52.1,<2.0.0"
 publication = ">=0.0.3"
 
 [[package]]
 name = "aws-cdk.cx-api"
-version = "1.130.0"
+version = "1.143.0"
 description = "Cloud executable protocol"
 category = "main"
 optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
-"aws-cdk.cloud-assembly-schema" = "1.130.0"
-jsii = ">=1.41.0,<2.0.0"
+"aws-cdk.cloud-assembly-schema" = "1.143.0"
+jsii = ">=1.52.1,<2.0.0"
 publication = ">=0.0.3"
 
 [[package]]
 name = "aws-cdk.region-info"
-version = "1.130.0"
+version = "1.143.0"
 description = "AWS region information, such as service principal names"
 category = "main"
 optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
-jsii = ">=1.41.0,<2.0.0"
+jsii = ">=1.52.1,<2.0.0"
 publication = ">=0.0.3"
 
 [[package]]
@@ -665,7 +683,7 @@ dev = ["bumpversion", "wheel", "watchdog", "flake8", "tox", "coverage", "sphinx"
 
 [[package]]
 name = "cattrs"
-version = "1.8.0"
+version = "1.10.0"
 description = "Composable complex class support for attrs and dataclasses."
 category = "main"
 optional = false
@@ -673,17 +691,18 @@ python-versions = ">=3.7,<4.0"
 
 [package.dependencies]
 attrs = ">=20"
+typing_extensions = {version = "*", markers = "python_version >= \"3.7\" and python_version < \"3.8\""}
 
 [[package]]
 name = "constructs"
-version = "3.3.161"
+version = "3.3.211"
 description = "A programming model for composable configuration"
 category = "main"
 optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
-jsii = ">=1.37.0,<2.0.0"
+jsii = ">=1.52.1,<2.0.0"
 publication = ">=0.0.3"
 
 [[package]]
@@ -703,7 +722,7 @@ testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-
 
 [[package]]
 name = "jsii"
-version = "1.42.0"
+version = "1.52.1"
 description = "Python client for jsii runtime"
 category = "main"
 optional = false
@@ -713,11 +732,11 @@ python-versions = "~=3.6"
 attrs = ">=21.2,<22.0"
 cattrs = [
     {version = ">=1.0.0,<1.1.0", markers = "python_version < \"3.7\""},
-    {version = ">=1.8.0,<1.9.0", markers = "python_version >= \"3.7\""},
+    {version = ">=1.8,<1.11", markers = "python_version >= \"3.7\""},
 ]
 importlib-resources = {version = "*", markers = "python_version < \"3.7\""}
 python-dateutil = "*"
-typing-extensions = ">=3.7,<4.0"
+typing-extensions = ">=3.7,<5.0"
 
 [[package]]
 name = "publication"
@@ -748,11 +767,11 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
 
 [[package]]
 name = "typing-extensions"
-version = "3.10.0.2"
-description = "Backported and Experimental Type Hints for Python 3.5+"
+version = "4.0.1"
+description = "Backported and Experimental Type Hints for Python 3.6+"
 category = "main"
 optional = false
-python-versions = "*"
+python-versions = ">=3.6"
 
 [[package]]
 name = "zipp"
@@ -768,175 +787,179 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytes
 
 [metadata]
 lock-version = "1.1"
-python-versions = ">=3.6.2, <3.10"
-content-hash = "6d22ad86171a44206a94d9e9d051c12bb4caf0215a7af535ae5e7d371011afc1"
+python-versions = ">=3.6.2, <3.11"
+content-hash = "5a07613f2b900e1d17d2a884287fd57a1590bc0ac6d335215dbb5f82819aac1e"
 
 [metadata.files]
 attrs = [
-    {file = "attrs-21.2.0-py2.py3-none-any.whl", hash = "sha256:149e90d6d8ac20db7a955ad60cf0e6881a3f20d37096140088356da6c716b0b1"},
-    {file = "attrs-21.2.0.tar.gz", hash = "sha256:ef6aaac3ca6cd92904cdd0d83f629a15f18053ec84e6432106f7a4d04ae4f5fb"},
+    {file = "attrs-21.4.0-py2.py3-none-any.whl", hash = "sha256:2d27e3784d7a565d36ab851fe94887c5eccd6a463168875832a1be79c82828b4"},
+    {file = "attrs-21.4.0.tar.gz", hash = "sha256:626ba8234211db98e869df76230a137c4c40a12d72445c45d5f5b716f076e2fd"},
 ]
 "aws-cdk.assets" = [
-    {file = "aws-cdk.assets-1.130.0.tar.gz", hash = "sha256:89628550ecfd4f2b3713cc515c5937ee766cc68cd39fc65dc15095a4fc92140f"},
-    {file = "aws_cdk.assets-1.130.0-py3-none-any.whl", hash = "sha256:88ee75118c7b34506acac8a3390e0f6360227f95764749ecf0cb8160532fef8d"},
+    {file = "aws-cdk.assets-1.143.0.tar.gz", hash = "sha256:180db4f9ff218356738c1c0eec7d23c1efd57d43949c231ba8ff255f895f4cd7"},
+    {file = "aws_cdk.assets-1.143.0-py3-none-any.whl", hash = "sha256:5ab25a3ab7d58dbbf9064233f37aeffedc392d47af960cbeb1f0d3d5203b7afb"},
+]
+"aws-cdk.aws-acmpca" = [
+    {file = "aws-cdk.aws-acmpca-1.143.0.tar.gz", hash = "sha256:9d333b29bcba89dda4778fd78d4813d5119af38bb92d949385f4e39d4b2a19cf"},
+    {file = "aws_cdk.aws_acmpca-1.143.0-py3-none-any.whl", hash = "sha256:96d77bd16e99331ebdfe4367b327a9467169cfa1eab6be94e01dfd61335d3143"},
 ]
 "aws-cdk.aws-applicationautoscaling" = [
-    {file = "aws-cdk.aws-applicationautoscaling-1.130.0.tar.gz", hash = "sha256:c60000e6a2b86392efcfb32066207cff19adbdbe0b68e1ee4281cf5b52255b29"},
-    {file = "aws_cdk.aws_applicationautoscaling-1.130.0-py3-none-any.whl", hash = "sha256:0bed99bbc03ae733450e03bd0c6b075fadc13ae0d9363fffa047e6de0d68be60"},
+    {file = "aws-cdk.aws-applicationautoscaling-1.143.0.tar.gz", hash = "sha256:8690023fe51f5a1ad8140213a9861c04d67ed95e1318cbb27024aaffc6941f7c"},
+    {file = "aws_cdk.aws_applicationautoscaling-1.143.0-py3-none-any.whl", hash = "sha256:3c1b2f53bcbf26f9272118628cccab774122916bb81f56bfa570ba237ad91bfe"},
 ]
 "aws-cdk.aws-autoscaling-common" = [
-    {file = "aws-cdk.aws-autoscaling-common-1.130.0.tar.gz", hash = "sha256:bdc5eee7f30163daf0a40b78e888d356da9815057153791daa6bc2b3d1288541"},
-    {file = "aws_cdk.aws_autoscaling_common-1.130.0-py3-none-any.whl", hash = "sha256:46bd7dffa2ff4bcb2c3ee86e4881d7994924f23f76b59fb346cbc48a7e5b90e4"},
+    {file = "aws-cdk.aws-autoscaling-common-1.143.0.tar.gz", hash = "sha256:9d8f27a0c094515c6d2ad405fc3490039b4f65d596ef9553bfa5cb7811f64526"},
+    {file = "aws_cdk.aws_autoscaling_common-1.143.0-py3-none-any.whl", hash = "sha256:507a458541c9e1053a37da3b52418b59ddb46cc66df7bd95586239660fb021c0"},
 ]
 "aws-cdk.aws-certificatemanager" = [
-    {file = "aws-cdk.aws-certificatemanager-1.130.0.tar.gz", hash = "sha256:e95cb1c48e5b37afa10ff0bdac0c0793d276f0c00d26140c6707a1fb0db74dc8"},
-    {file = "aws_cdk.aws_certificatemanager-1.130.0-py3-none-any.whl", hash = "sha256:23ceb0486f5e17ed230a651401ce9807faf3efffe793b0e1cef7e224f6ed25c9"},
+    {file = "aws-cdk.aws-certificatemanager-1.143.0.tar.gz", hash = "sha256:8f46b6d0d8d806517e1f4d8ef2e06d9f70012d28ca9f337b1934368be9197ba5"},
+    {file = "aws_cdk.aws_certificatemanager-1.143.0-py3-none-any.whl", hash = "sha256:8d0399d2a25a27883c43c782ec4b793e5e37d77b85f22815d9669ef7efdb68ab"},
 ]
 "aws-cdk.aws-cloudformation" = [
-    {file = "aws-cdk.aws-cloudformation-1.130.0.tar.gz", hash = "sha256:c2176461dfd6bf46ad3143f9ca270e209e74d6a1f8d52e2260f4893b4b9ae228"},
-    {file = "aws_cdk.aws_cloudformation-1.130.0-py3-none-any.whl", hash = "sha256:0509fc5b6b6a6bae3752fe04a4b3f24776254e28bc5688238602b904852bd2ec"},
+    {file = "aws-cdk.aws-cloudformation-1.143.0.tar.gz", hash = "sha256:29549ccc068903456a5916f008fce2e0f93f5f24e22dc61db3850d1b9ce534ec"},
+    {file = "aws_cdk.aws_cloudformation-1.143.0-py3-none-any.whl", hash = "sha256:35f41457712be3e92b374fcfd4766c24cb166154b09a483fecad14f25358553c"},
 ]
 "aws-cdk.aws-cloudwatch" = [
-    {file = "aws-cdk.aws-cloudwatch-1.130.0.tar.gz", hash = "sha256:1034ca75148e8292d014927911ba45cb18fad459371988ed32afd4b9de999449"},
-    {file = "aws_cdk.aws_cloudwatch-1.130.0-py3-none-any.whl", hash = "sha256:10cbd1b7047267a6a1f566e7f1bfd1e85932a709bbca5419226d1b84b7e0a0ee"},
+    {file = "aws-cdk.aws-cloudwatch-1.143.0.tar.gz", hash = "sha256:ba87dad398e203710e6a03b6dbbe5cca899acb25d7c5b37d3ecf04ba237aa66b"},
+    {file = "aws_cdk.aws_cloudwatch-1.143.0-py3-none-any.whl", hash = "sha256:3401d03a3fc2881662faf3df7b622c7fe72724648620a96e292c541a169c111c"},
 ]
 "aws-cdk.aws-codeguruprofiler" = [
-    {file = "aws-cdk.aws-codeguruprofiler-1.130.0.tar.gz", hash = "sha256:b9d9473a3e052e3164759c3f1ee694b7fc9d604c92b4a3df36c31a1a92306917"},
-    {file = "aws_cdk.aws_codeguruprofiler-1.130.0-py3-none-any.whl", hash = "sha256:0462eb79554b407bed707eda3f840956ec81d442ddfad4a1e93da20c89152835"},
+    {file = "aws-cdk.aws-codeguruprofiler-1.143.0.tar.gz", hash = "sha256:bbd358dd1586ab41e689bfcd02d00a5989ce8310f35af063ab249af6778a55a1"},
+    {file = "aws_cdk.aws_codeguruprofiler-1.143.0-py3-none-any.whl", hash = "sha256:136f13714ade24bb10eb667496d1314fa4710c0bd93fe44efd3897c8a4e9d161"},
 ]
 "aws-cdk.aws-codestarnotifications" = [
-    {file = "aws-cdk.aws-codestarnotifications-1.130.0.tar.gz", hash = "sha256:3c7f66d4c377e4f509b2719be4a2b1ac6efdbc4ab416eb56947a57ddd9290e27"},
-    {file = "aws_cdk.aws_codestarnotifications-1.130.0-py3-none-any.whl", hash = "sha256:89b8a5374616e732475f374acb1f8b26de20721e0d939dda733f7135754848e3"},
+    {file = "aws-cdk.aws-codestarnotifications-1.143.0.tar.gz", hash = "sha256:332e3120002341bdc7b3314ec2fb0f5d81d75469a0f982e88f7765f2824bf456"},
+    {file = "aws_cdk.aws_codestarnotifications-1.143.0-py3-none-any.whl", hash = "sha256:432d992581ef961ccd2f3490d9b6d5fdcbe26a3236253a8496c143f7a81ecbee"},
 ]
 "aws-cdk.aws-ec2" = [
-    {file = "aws-cdk.aws-ec2-1.130.0.tar.gz", hash = "sha256:e0220bc03d44ad4e7f04c8efacd65c52c32faeac3d62a752d114e5606c47a6c2"},
-    {file = "aws_cdk.aws_ec2-1.130.0-py3-none-any.whl", hash = "sha256:fde2b2252debcbdd309a74bf7f3c1b7aaa83a671511eb9f753105687e59cafc3"},
+    {file = "aws-cdk.aws-ec2-1.143.0.tar.gz", hash = "sha256:2b6b359ac99fd89f820744d0efd3f835fb0a8df6f3b82be201feb71e10bbcff4"},
+    {file = "aws_cdk.aws_ec2-1.143.0-py3-none-any.whl", hash = "sha256:9b6858dfed1b0207f810a35d73b2c0804c36f8722ac2f49d0225a20349defb06"},
 ]
 "aws-cdk.aws-ecr" = [
-    {file = "aws-cdk.aws-ecr-1.130.0.tar.gz", hash = "sha256:0c3aad603cc3f8e7cf2901d9a1365fe5110ff46f7d739b89333691219b186b92"},
-    {file = "aws_cdk.aws_ecr-1.130.0-py3-none-any.whl", hash = "sha256:7a2f8720d2f23c3578979c53f486c66a8449e0fd8135c6e4f82d4bd653151ce9"},
+    {file = "aws-cdk.aws-ecr-1.143.0.tar.gz", hash = "sha256:50eb433cd4b948b75b67258a477d5239b5153252ed0ce5d541977053dd2c51a7"},
+    {file = "aws_cdk.aws_ecr-1.143.0-py3-none-any.whl", hash = "sha256:1189e3b587fccbedeb6858aeb6db55014b5c1f9e9b2476092e6cdcebd94ac768"},
 ]
 "aws-cdk.aws-ecr-assets" = [
-    {file = "aws-cdk.aws-ecr-assets-1.130.0.tar.gz", hash = "sha256:40ca779cde59bdc3fcd979385a2b87b8e5cb052e1a4ef76e43bd781458ea5ce3"},
-    {file = "aws_cdk.aws_ecr_assets-1.130.0-py3-none-any.whl", hash = "sha256:ddf5078a87529b4e5c2216bb71579fc0489b4dcdab6e7d5246dd1e1d10263e29"},
+    {file = "aws-cdk.aws-ecr-assets-1.143.0.tar.gz", hash = "sha256:72d82b6540a53f154e403de4b987a56b7385f78bde0a9ed0fb6de9cc11ebde9d"},
+    {file = "aws_cdk.aws_ecr_assets-1.143.0-py3-none-any.whl", hash = "sha256:e8d386d9affabae669f49a98f2160369c1d9925bbf7576f0cf495f548e3f9b2e"},
 ]
 "aws-cdk.aws-efs" = [
-    {file = "aws-cdk.aws-efs-1.130.0.tar.gz", hash = "sha256:8ed017fe4599bbfaa03dac74aa41cded39984813c8a6b14e280896aed0c8a39a"},
-    {file = "aws_cdk.aws_efs-1.130.0-py3-none-any.whl", hash = "sha256:ccf15abb0711725620d478f7b53e58f2f6109b77f6c47c5878dc00d70e196827"},
+    {file = "aws-cdk.aws-efs-1.143.0.tar.gz", hash = "sha256:332484cfaf0751c4385e75e410880d94bbca15994f2dfef490fc25a703a46b6c"},
+    {file = "aws_cdk.aws_efs-1.143.0-py3-none-any.whl", hash = "sha256:d4dd4a48d872c508b40992be11e715fe80189536618fcea8dc2e6702442183d7"},
 ]
 "aws-cdk.aws-events" = [
-    {file = "aws-cdk.aws-events-1.130.0.tar.gz", hash = "sha256:6ee24457c50eeda8c9c241596cfa6b123bb50ea2138787fef3e4bb54e4b47f13"},
-    {file = "aws_cdk.aws_events-1.130.0-py3-none-any.whl", hash = "sha256:df91c72843d9734a49017040090b1615be41de020906a57e6c708d860e8a4139"},
+    {file = "aws-cdk.aws-events-1.143.0.tar.gz", hash = "sha256:cd9f6f9a7875b967b4f722cfc727a2a926efe67c835f5799f935bd6694b4daa0"},
+    {file = "aws_cdk.aws_events-1.143.0-py3-none-any.whl", hash = "sha256:0be4ac64c8e30ce9aa545c410f94b006d4c891dc54584177597a0eaeacb0230a"},
 ]
 "aws-cdk.aws-glue" = [
-    {file = "aws-cdk.aws-glue-1.130.0.tar.gz", hash = "sha256:4ddda00ad580ffe207f2241a3cc66ab6c5a225580a9daa6adcd03c3299017d9a"},
-    {file = "aws_cdk.aws_glue-1.130.0-py3-none-any.whl", hash = "sha256:93f136d74b866619bd3aec2086b5a2c2b930acfaad7cc23cfa2f0b2a2eb85f90"},
+    {file = "aws-cdk.aws-glue-1.143.0.tar.gz", hash = "sha256:f71815faa5132f9fd0d353ae60fe81aaf8bb3cc5bdea2e61d1d673c342d38329"},
+    {file = "aws_cdk.aws_glue-1.143.0-py3-none-any.whl", hash = "sha256:0b276bac0ce76c4113d8d5d14190e8ead66054926b7ac70d6d85542fb67b5e5c"},
 ]
 "aws-cdk.aws-iam" = [
-    {file = "aws-cdk.aws-iam-1.130.0.tar.gz", hash = "sha256:d2bf02a2d3f2bd81c1b9598e7b4424b0dc0d4694b57338d7efac43a89fb6409c"},
-    {file = "aws_cdk.aws_iam-1.130.0-py3-none-any.whl", hash = "sha256:3a3272745da9363177ebd8b138f42ce9407439f909ed9177c226e584022f4ff0"},
+    {file = "aws-cdk.aws-iam-1.143.0.tar.gz", hash = "sha256:c2f28afd1ea3b87c02a9da0c5719048ba32dd7b81740842d10c0d8cf585dd78d"},
+    {file = "aws_cdk.aws_iam-1.143.0-py3-none-any.whl", hash = "sha256:1b2d1ffa8538488249d6ed9efe54b85944fc30def92311c9f23625f665b9bd87"},
 ]
 "aws-cdk.aws-kms" = [
-    {file = "aws-cdk.aws-kms-1.130.0.tar.gz", hash = "sha256:1ece4b6753b0271d9164b32c0c94919e2f2a587677b19c554c2a990b5b0803b7"},
-    {file = "aws_cdk.aws_kms-1.130.0-py3-none-any.whl", hash = "sha256:de50127ab5f5f3838b6e4e549696ccfcd2cf18f7edd50616f82b1a0ddcd10075"},
+    {file = "aws-cdk.aws-kms-1.143.0.tar.gz", hash = "sha256:d6d5ff9a6262ab7772af181e04385264169f81cace70741a525af8f734bf4ecc"},
+    {file = "aws_cdk.aws_kms-1.143.0-py3-none-any.whl", hash = "sha256:5587021dd6d85414fe5ff71654512b9d98b53c3b58a3e97258806ff803791f22"},
 ]
 "aws-cdk.aws-lakeformation" = [
-    {file = "aws-cdk.aws-lakeformation-1.130.0.tar.gz", hash = "sha256:bdf37b0047ed48c4fa70c5a9398b596f278a73abf4b912b6eb289fa8aeb96ca7"},
-    {file = "aws_cdk.aws_lakeformation-1.130.0-py3-none-any.whl", hash = "sha256:5bcd04992577dc2b67d437e0d73b3367e3b57315859a5c9426f15501db049151"},
+    {file = "aws-cdk.aws-lakeformation-1.143.0.tar.gz", hash = "sha256:e2b77b36bebe390c99c68ded8aa3c4fe1673702a3aba7e38b93502bdc3258e59"},
+    {file = "aws_cdk.aws_lakeformation-1.143.0-py3-none-any.whl", hash = "sha256:fddcbcc76d7c7df2587a68b0fbccec1d6197aa56a8add92398db7b6b139fe6c3"},
 ]
 "aws-cdk.aws-lambda" = [
-    {file = "aws-cdk.aws-lambda-1.130.0.tar.gz", hash = "sha256:c3ee7c637f1a590ead83e75803865f58c0c18193ff841d94b0a0b51ea1e9d6fb"},
-    {file = "aws_cdk.aws_lambda-1.130.0-py3-none-any.whl", hash = "sha256:6c8dec3aad5d3900888aab52b0a844d3c05e94f977ff04ec26083302cc76edc8"},
+    {file = "aws-cdk.aws-lambda-1.143.0.tar.gz", hash = "sha256:c698a1f9d2e235f170a593c7735be957fa45089a556b211a112c5e1f7a1ad6f3"},
+    {file = "aws_cdk.aws_lambda-1.143.0-py3-none-any.whl", hash = "sha256:0beec57fde30d04070f4d788c89956e41466550e7c114599cd6f30ac8b6ee54c"},
 ]
 "aws-cdk.aws-logs" = [
-    {file = "aws-cdk.aws-logs-1.130.0.tar.gz", hash = "sha256:d022ec78f953f1276d710e903ee75857fe86a05b1f44f1610ac4d52b8652ddfc"},
-    {file = "aws_cdk.aws_logs-1.130.0-py3-none-any.whl", hash = "sha256:da8ff0e9ed334bb4bc34cac698ad46ae8e815c7e9018e3754c9a342b84f26bbb"},
+    {file = "aws-cdk.aws-logs-1.143.0.tar.gz", hash = "sha256:ab1393000cdf9b6a9263ac4c2e079dc761cb6124a98adab04f9bd87e42240288"},
+    {file = "aws_cdk.aws_logs-1.143.0-py3-none-any.whl", hash = "sha256:4feed8b57b1e5be0272b836e38d211163f8b799d7a836a7b17ea400bc83f0108"},
 ]
 "aws-cdk.aws-opensearchservice" = [
-    {file = "aws-cdk.aws-opensearchservice-1.130.0.tar.gz", hash = "sha256:4194f91d28b50a4dc7b97d773871798a79bd93774146cfb8d2fe0ad30030328b"},
-    {file = "aws_cdk.aws_opensearchservice-1.130.0-py3-none-any.whl", hash = "sha256:b4bb3b0a80f883aeeae79417ef45c5fc1f46abd05dfa9c46bd02476d5083af39"},
+    {file = "aws-cdk.aws-opensearchservice-1.143.0.tar.gz", hash = "sha256:ea27a781249aaab879cedc92c2a7ce6feab6c9d8b78ecff174bff038ea6a784f"},
+    {file = "aws_cdk.aws_opensearchservice-1.143.0-py3-none-any.whl", hash = "sha256:bc4fca7e055d1cbe5b6c60e98688515f918150df5f8b8e12915f1d037ac1d660"},
 ]
 "aws-cdk.aws-rds" = [
-    {file = "aws-cdk.aws-rds-1.130.0.tar.gz", hash = "sha256:316abaa5786703bf1459f538d8d1bcc02f5b4c75df320fe2e9d62821f92fa7f4"},
-    {file = "aws_cdk.aws_rds-1.130.0-py3-none-any.whl", hash = "sha256:a781ca1b945f655797f06106eb72142be4d1d6b9278e707a29a7e75d7e8dea73"},
+    {file = "aws-cdk.aws-rds-1.143.0.tar.gz", hash = "sha256:9cb153a9689b605e5794c181d2f5b0dbb04821b04a197498c2a7d467ea1e1aaf"},
+    {file = "aws_cdk.aws_rds-1.143.0-py3-none-any.whl", hash = "sha256:574338a376f499c860e968530a3ab2884ff139e9ca5ea68597163b595edd3d68"},
 ]
 "aws-cdk.aws-redshift" = [
-    {file = "aws-cdk.aws-redshift-1.130.0.tar.gz", hash = "sha256:7447af727af2ff2014aad2d04a96ef70ffc6e65142d575dffb762cd147067e06"},
-    {file = "aws_cdk.aws_redshift-1.130.0-py3-none-any.whl", hash = "sha256:e60832a9a042eaeeb646769a40753a82b807dc1154df58c20d524010e361c5b0"},
+    {file = "aws-cdk.aws-redshift-1.143.0.tar.gz", hash = "sha256:e163ca3405229909ae3929d1097d980ac815b24b3535259a2e0c7be27f5e894f"},
+    {file = "aws_cdk.aws_redshift-1.143.0-py3-none-any.whl", hash = "sha256:b89e792aeb73f4019ea607f083f002730205bde3792e6c3f6e8487969e2f6251"},
 ]
 "aws-cdk.aws-route53" = [
-    {file = "aws-cdk.aws-route53-1.130.0.tar.gz", hash = "sha256:6d1a209505e794922718cbf2f8f432f8d51b305da63ad4f10008b8f1f535f526"},
-    {file = "aws_cdk.aws_route53-1.130.0-py3-none-any.whl", hash = "sha256:270877be4a1469f84c3022300baba2b982cd1644b4ea01d65fb0522adcf9b822"},
+    {file = "aws-cdk.aws-route53-1.143.0.tar.gz", hash = "sha256:d5a29c0301d2fc3bf447b2676794bb10467a03c89e36254b54e123ef38191258"},
+    {file = "aws_cdk.aws_route53-1.143.0-py3-none-any.whl", hash = "sha256:ed25524b335735f606550078fb33602b0ffdde3767bd6abd074b83885755d587"},
 ]
 "aws-cdk.aws-s3" = [
-    {file = "aws-cdk.aws-s3-1.130.0.tar.gz", hash = "sha256:940bcb081783937e774cf4f44f77ba7a8211ebe9440cca2d7225b310f4272f79"},
-    {file = "aws_cdk.aws_s3-1.130.0-py3-none-any.whl", hash = "sha256:9fac2a150adf92700c05a02c603d0ff1185894235443980fafc874354c380f52"},
+    {file = "aws-cdk.aws-s3-1.143.0.tar.gz", hash = "sha256:4d50b5702dbb7ef61399fa43d7715cebb9f7eb4feb6646156a19754f8ca076c8"},
+    {file = "aws_cdk.aws_s3-1.143.0-py3-none-any.whl", hash = "sha256:ec01155c157d88ffd7c5eff0dc79fbadf87c8c6eddaf03e035f595e6d61a3651"},
 ]
 "aws-cdk.aws-s3-assets" = [
-    {file = "aws-cdk.aws-s3-assets-1.130.0.tar.gz", hash = "sha256:db33b348222895ad14cb9d52d5582b1e80d0e9ff008f8c10ea912499ab7c14f1"},
-    {file = "aws_cdk.aws_s3_assets-1.130.0-py3-none-any.whl", hash = "sha256:01a5b0f2c759a88176929569c6f69d0efb8901452fe112cfd3b3f4782fec12ab"},
+    {file = "aws-cdk.aws-s3-assets-1.143.0.tar.gz", hash = "sha256:2276f65b47cc1be42269a668a862567cb585070052ec6431489ce3a84d1abd02"},
+    {file = "aws_cdk.aws_s3_assets-1.143.0-py3-none-any.whl", hash = "sha256:4356df23315d53e6fbcf55a9f48fe0cff45a04d0141965e889ae8fcc37b032f2"},
 ]
 "aws-cdk.aws-sam" = [
-    {file = "aws-cdk.aws-sam-1.130.0.tar.gz", hash = "sha256:564877af10684b99a76d7ae83b888f9dfc1f7894caed81d5349a059f51430836"},
-    {file = "aws_cdk.aws_sam-1.130.0-py3-none-any.whl", hash = "sha256:dbd38e5e52b5f94aff76bc18640e8ba11ae0d0b183867f747942c753935bf326"},
+    {file = "aws-cdk.aws-sam-1.143.0.tar.gz", hash = "sha256:3da84163060e27e1984243ca1e8a941fbc3639d74fe4bad47b83174666bcb8ad"},
+    {file = "aws_cdk.aws_sam-1.143.0-py3-none-any.whl", hash = "sha256:9cede0d9f3ed23cbb6d70cf8a0b2be1907cb8334067b7d9714b21ef1cc14a1ba"},
 ]
 "aws-cdk.aws-secretsmanager" = [
-    {file = "aws-cdk.aws-secretsmanager-1.130.0.tar.gz", hash = "sha256:96e52bd3e6523b22f1d60aadeb0b6f435a5276a1ec794e4cfe2294f8ac26259a"},
-    {file = "aws_cdk.aws_secretsmanager-1.130.0-py3-none-any.whl", hash = "sha256:a929ef9fea760b37d5306a1ee9deeecbac2530ab2ea7ec1fc1085544e6af1ca0"},
+    {file = "aws-cdk.aws-secretsmanager-1.143.0.tar.gz", hash = "sha256:e574d80016d0a9bb0595c5d3e73eb0f9b020714d0cb552fee81e8dcf2a37218c"},
+    {file = "aws_cdk.aws_secretsmanager-1.143.0-py3-none-any.whl", hash = "sha256:92faa27df7941dd824bb2d99039c9867d1a017ae34ad6b0587d2876a6059c497"},
 ]
 "aws-cdk.aws-signer" = [
-    {file = "aws-cdk.aws-signer-1.130.0.tar.gz", hash = "sha256:f453d608a491dd0ff7d97fa597f17480d3bf43a0eaedd975e0846bf03de0ab0d"},
-    {file = "aws_cdk.aws_signer-1.130.0-py3-none-any.whl", hash = "sha256:10a5981156c83c8725f565931167b376db24c08d43b325a8ad0e4a10559b32df"},
+    {file = "aws-cdk.aws-signer-1.143.0.tar.gz", hash = "sha256:482ed38d13f8a5b9aab6c077d9f6bd958047be2be44fc9774eb6061c61dd4bd8"},
+    {file = "aws_cdk.aws_signer-1.143.0-py3-none-any.whl", hash = "sha256:6235fdcdc806df967b723be7c68e2f34a5af7b4e29271af3273f0b96af268af5"},
 ]
 "aws-cdk.aws-sns" = [
-    {file = "aws-cdk.aws-sns-1.130.0.tar.gz", hash = "sha256:a2494dd42513b870ef94c0f013e734473fb8a02042b21da5864e3b8bd6609963"},
-    {file = "aws_cdk.aws_sns-1.130.0-py3-none-any.whl", hash = "sha256:7b6dfc5c50cdc0005caac683731772502a9d26d6ef415256f21746bef0b7b444"},
+    {file = "aws-cdk.aws-sns-1.143.0.tar.gz", hash = "sha256:c46aea3292408634b28858402a90dcbe3407ccf6ae3c71abd3fef3414a01959f"},
+    {file = "aws_cdk.aws_sns-1.143.0-py3-none-any.whl", hash = "sha256:e2142cc9687b3a64b97488fae86faf5fd4f755858496e6e55d67e03a96d6ecf4"},
 ]
 "aws-cdk.aws-sqs" = [
-    {file = "aws-cdk.aws-sqs-1.130.0.tar.gz", hash = "sha256:baef9bfc74c33ad5e9ff65a4d48477f68fb503950d58d21e9cc657e8a9914c0f"},
-    {file = "aws_cdk.aws_sqs-1.130.0-py3-none-any.whl", hash = "sha256:bd40f528012fd38398dd7cc6a8c91c62da634e2e620ecfa6530ae43a5d1890b5"},
+    {file = "aws-cdk.aws-sqs-1.143.0.tar.gz", hash = "sha256:d68a26bdea6f95632a5bd62c326b6a60630ba546668e2fc5c5c2d6619261a610"},
+    {file = "aws_cdk.aws_sqs-1.143.0-py3-none-any.whl", hash = "sha256:e584e60c57f63343646a95bb1c81f1952dc6db7e33a483268a75d38584633277"},
 ]
 "aws-cdk.aws-ssm" = [
-    {file = "aws-cdk.aws-ssm-1.130.0.tar.gz", hash = "sha256:2c0a2e400b82864233e76973020dc16e88afc35aa0ef4dd5250d0404e1236de0"},
-    {file = "aws_cdk.aws_ssm-1.130.0-py3-none-any.whl", hash = "sha256:dd84d306f4794433b921f75081d3db41dfe6fdc6078bfa377a096a1457adc9a9"},
+    {file = "aws-cdk.aws-ssm-1.143.0.tar.gz", hash = "sha256:c75e8bf4e59c1b6702a33ee74ae653cca622160f20668e8b18da44187a3211b1"},
+    {file = "aws_cdk.aws_ssm-1.143.0-py3-none-any.whl", hash = "sha256:51ea415268f5356509e952c903732fdb5f6194254e5d166719b1a3bf3d7513ad"},
 ]
 "aws-cdk.cloud-assembly-schema" = [
-    {file = "aws-cdk.cloud-assembly-schema-1.130.0.tar.gz", hash = "sha256:31231d1fa14037f2af0a0a27657c7e603103c876464868bb8a5731698dba9d7f"},
-    {file = "aws_cdk.cloud_assembly_schema-1.130.0-py3-none-any.whl", hash = "sha256:3eadde99a914ca53e101e66a403b554537435a29e1954cb13e94cdc9305da48a"},
+    {file = "aws-cdk.cloud-assembly-schema-1.143.0.tar.gz", hash = "sha256:bb0c472de882f4864e931775499b94706e07f498ce470dd328153adcf5e451f7"},
+    {file = "aws_cdk.cloud_assembly_schema-1.143.0-py3-none-any.whl", hash = "sha256:a5bb94ed4d219d20784d26aa5b95bab93e61d44dc193c2f6d546b2854fae94b0"},
 ]
 "aws-cdk.core" = [
-    {file = "aws-cdk.core-1.130.0.tar.gz", hash = "sha256:d07b98dad35b18481e46b92b6fde7061b76730ac9d1111849db321e519ebdc52"},
-    {file = "aws_cdk.core-1.130.0-py3-none-any.whl", hash = "sha256:7b3f1d0e9f83263763694cfb814346c38984041226180fe298056670fa5a5bd9"},
+    {file = "aws-cdk.core-1.143.0.tar.gz", hash = "sha256:a2dfb118a0e3d6d89a0dd1f7ce165dcd1c5799248f079cf1232ef3dd0a5b8993"},
+    {file = "aws_cdk.core-1.143.0-py3-none-any.whl", hash = "sha256:0c62c3c8c53e16a4bde15168341282fb1cd57763d5753648b77fd49b9021c3f5"},
 ]
 "aws-cdk.custom-resources" = [
-    {file = "aws-cdk.custom-resources-1.130.0.tar.gz", hash = "sha256:c212447b64f79d3605db6e072d23acc6fa1135e5399162a8cd258bc1d22e03e2"},
-    {file = "aws_cdk.custom_resources-1.130.0-py3-none-any.whl", hash = "sha256:07c8a6c99bfe53d251303a7cf50b109fa974ddfd2fdbd22f3e94534271a2f666"},
+    {file = "aws-cdk.custom-resources-1.143.0.tar.gz", hash = "sha256:98a5c5974de0926b91eab1bd16b48c3ff9342941ef4e3080cae64b254174bd5b"},
+    {file = "aws_cdk.custom_resources-1.143.0-py3-none-any.whl", hash = "sha256:b9ab3f581ff53561d11e2e07a3bab8eb0a43eef51a7785287b0c62edf9d58c37"},
 ]
 "aws-cdk.cx-api" = [
-    {file = "aws-cdk.cx-api-1.130.0.tar.gz", hash = "sha256:3640cdc3c34566bbd0f32fd899fd5ea969d266d0efcd14f67784e557d2c7192c"},
-    {file = "aws_cdk.cx_api-1.130.0-py3-none-any.whl", hash = "sha256:26b425e11e0718f531b6578e0621f141089ec1946ccfa124f929ae932f8340a6"},
+    {file = "aws-cdk.cx-api-1.143.0.tar.gz", hash = "sha256:df35fa394bbb1f5ff416da3dccfa80d928b9781a14919e6b15b4db2fe060e6bf"},
+    {file = "aws_cdk.cx_api-1.143.0-py3-none-any.whl", hash = "sha256:ad225f6d10a51147d6a29cafdf87fde6a54836c539b222908a8073999bff3bc5"},
 ]
 "aws-cdk.region-info" = [
-    {file = "aws-cdk.region-info-1.130.0.tar.gz", hash = "sha256:f5534c3c02cc25215cca2d74aee4dc70cd34b35d86550415a085db65851b135e"},
-    {file = "aws_cdk.region_info-1.130.0-py3-none-any.whl", hash = "sha256:2d4110779dd87f405270bfb31c73f315898698af04ec23b8069cc444d0bd896e"},
+    {file = "aws-cdk.region-info-1.143.0.tar.gz", hash = "sha256:feb85ad58f4f4da7eced7d88853895246ab71a64156a13195b172dad920470d7"},
+    {file = "aws_cdk.region_info-1.143.0-py3-none-any.whl", hash = "sha256:3c1c450b6cae5926cbe5a3ae3dfefc25d88e8a3fad5000a68eafb0240f858bbd"},
 ]
 cattrs = [
     {file = "cattrs-1.0.0-py2.py3-none-any.whl", hash = "sha256:616972ae3dfa6e623a40ad3cb845420e64942989152774ab055e5c2b2f89f997"},
     {file = "cattrs-1.0.0.tar.gz", hash = "sha256:b7ab5cf8ad127c42eefd01410c1c6e28569a45a255ea80ed968511873c433c7a"},
-    {file = "cattrs-1.8.0-py3-none-any.whl", hash = "sha256:901fb2040529ae8fc9d93f48a2cdf7de3e983312ffb2a164ffa4e9847f253af1"},
-    {file = "cattrs-1.8.0.tar.gz", hash = "sha256:5c121ab06a7cac494813c228721a7feb5a6423b17316eeaebf13f5a03e5b0d53"},
+    {file = "cattrs-1.10.0-py3-none-any.whl", hash = "sha256:35dd9063244263e63bd0bd24ea61e3015b00272cead084b2c40d788b0f857c46"},
+    {file = "cattrs-1.10.0.tar.gz", hash = "sha256:211800f725cdecedcbcf4c753bbd22d248312b37d130f06045434acb7d9b34e1"},
 ]
 constructs = [
-    {file = "constructs-3.3.161-py3-none-any.whl", hash = "sha256:3215f2a3628584ad8e6a5ebabf4e1cc0b125367f2347e6fa0d9ccfd735ac2bbb"},
-    {file = "constructs-3.3.161.tar.gz", hash = "sha256:2b33c412ff0f1d21205d85f778e4594a35c9c98b65cb47fea7533fbe40de1730"},
+    {file = "constructs-3.3.211-py3-none-any.whl", hash = "sha256:222dd9467dd01b4db1cadfdd7d1aa4cdbc1e0bc195716151acc25347c238e1b1"},
+    {file = "constructs-3.3.211.tar.gz", hash = "sha256:302d881e970c624b2e967adc7b74337a95a90ab6b102caa2d366046adf9501cb"},
 ]
 importlib-resources = [
     {file = "importlib_resources-5.4.0-py3-none-any.whl", hash = "sha256:33a95faed5fc19b4bc16b29a6eeae248a3fe69dd55d4d229d2b480e23eeaad45"},
     {file = "importlib_resources-5.4.0.tar.gz", hash = "sha256:d756e2f85dd4de2ba89be0b21dba2a3bbec2e871a42a3a16719258a11f87506b"},
 ]
 jsii = [
-    {file = "jsii-1.42.0-py3-none-any.whl", hash = "sha256:29a4c87c8e1ad7eb67b65b03775f37bdd2212088a1eb854e84f5b541b9eaceb4"},
-    {file = "jsii-1.42.0.tar.gz", hash = "sha256:44a1874464c3c9b48417523d5a4790ee792dab6e6f522bc6e6e2c84e42417323"},
+    {file = "jsii-1.52.1-py3-none-any.whl", hash = "sha256:c1477f17275d62fbda28ea25c1f0a6cd1d95c1b73dda70835f33e34f0b70ac52"},
+    {file = "jsii-1.52.1.tar.gz", hash = "sha256:32f886e99c06a23943986e9580f553860aabeb91dc3a3520d5b76fef1e631c04"},
 ]
 publication = [
     {file = "publication-0.0.3-py2.py3-none-any.whl", hash = "sha256:0248885351febc11d8a1098d5c8e3ab2dabcf3e8c0c96db1e17ecd12b53afbe6"},
@@ -951,9 +974,8 @@ six = [
     {file = "six-1.16.0.tar.gz", hash = "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"},
 ]
 typing-extensions = [
-    {file = "typing_extensions-3.10.0.2-py2-none-any.whl", hash = "sha256:d8226d10bc02a29bcc81df19a26e56a9647f8b0a6d4a83924139f4a8b01f17b7"},
-    {file = "typing_extensions-3.10.0.2-py3-none-any.whl", hash = "sha256:f1d25edafde516b146ecd0613dabcc61409817af4766fbbcfb8d1ad4ec441a34"},
-    {file = "typing_extensions-3.10.0.2.tar.gz", hash = "sha256:49f75d16ff11f1cd258e1b988ccff82a3ca5570217d7ad8c5f48205dd99a677e"},
+    {file = "typing_extensions-4.0.1-py3-none-any.whl", hash = "sha256:7f001e5ac290a0c0401508864c7ec868be4e701886d5b573a9528ed3973d9d3b"},
+    {file = "typing_extensions-4.0.1.tar.gz", hash = "sha256:4ca091dea149f945ec56afb48dae714f21e8692ef22a395223bcd328961b6a0e"},
 ]
 zipp = [
     {file = "zipp-3.6.0-py3-none-any.whl", hash = "sha256:9fe5ea21568a0a70e50f273397638d39b03353731e6cbbb3fd8502a33fec40bc"},

--- a/test_infra/poetry.lock
+++ b/test_infra/poetry.lock
@@ -1,670 +1,652 @@
 [[package]]
 name = "attrs"
-version = "21.4.0"
+version = "21.2.0"
 description = "Classes Without Boilerplate"
 category = "main"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [package.extras]
-dev = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins", "zope.interface", "furo", "sphinx", "sphinx-notfound-page", "pre-commit", "cloudpickle"]
+dev = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins", "zope.interface", "furo", "sphinx", "sphinx-notfound-page", "pre-commit"]
 docs = ["furo", "sphinx", "zope.interface", "sphinx-notfound-page"]
-tests = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins", "zope.interface", "cloudpickle"]
-tests_no_zope = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins", "cloudpickle"]
+tests = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins", "zope.interface"]
+tests_no_zope = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins"]
 
 [[package]]
 name = "aws-cdk.assets"
-version = "1.143.0"
+version = "1.130.0"
 description = "This module is deprecated. All types are now available under the core module"
 category = "main"
 optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
-"aws-cdk.core" = "1.143.0"
-"aws-cdk.cx-api" = "1.143.0"
+"aws-cdk.core" = "1.130.0"
+"aws-cdk.cx-api" = "1.130.0"
 constructs = ">=3.3.69,<4.0.0"
-jsii = ">=1.52.1,<2.0.0"
-publication = ">=0.0.3"
-
-[[package]]
-name = "aws-cdk.aws-acmpca"
-version = "1.143.0"
-description = "The CDK Construct Library for AWS::ACMPCA"
-category = "main"
-optional = false
-python-versions = ">=3.6"
-
-[package.dependencies]
-"aws-cdk.core" = "1.143.0"
-constructs = ">=3.3.69,<4.0.0"
-jsii = ">=1.52.1,<2.0.0"
+jsii = ">=1.41.0,<2.0.0"
 publication = ">=0.0.3"
 
 [[package]]
 name = "aws-cdk.aws-applicationautoscaling"
-version = "1.143.0"
+version = "1.130.0"
 description = "The CDK Construct Library for AWS::ApplicationAutoScaling"
 category = "main"
 optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
-"aws-cdk.aws-autoscaling-common" = "1.143.0"
-"aws-cdk.aws-cloudwatch" = "1.143.0"
-"aws-cdk.aws-iam" = "1.143.0"
-"aws-cdk.core" = "1.143.0"
+"aws-cdk.aws-autoscaling-common" = "1.130.0"
+"aws-cdk.aws-cloudwatch" = "1.130.0"
+"aws-cdk.aws-iam" = "1.130.0"
+"aws-cdk.core" = "1.130.0"
 constructs = ">=3.3.69,<4.0.0"
-jsii = ">=1.52.1,<2.0.0"
+jsii = ">=1.41.0,<2.0.0"
 publication = ">=0.0.3"
 
 [[package]]
 name = "aws-cdk.aws-autoscaling-common"
-version = "1.143.0"
+version = "1.130.0"
 description = "Common implementation package for @aws-cdk/aws-autoscaling and @aws-cdk/aws-applicationautoscaling"
 category = "main"
 optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
-"aws-cdk.aws-iam" = "1.143.0"
-"aws-cdk.core" = "1.143.0"
+"aws-cdk.aws-iam" = "1.130.0"
+"aws-cdk.core" = "1.130.0"
 constructs = ">=3.3.69,<4.0.0"
-jsii = ">=1.52.1,<2.0.0"
+jsii = ">=1.41.0,<2.0.0"
 publication = ">=0.0.3"
 
 [[package]]
 name = "aws-cdk.aws-certificatemanager"
-version = "1.143.0"
+version = "1.130.0"
 description = "The CDK Construct Library for AWS::CertificateManager"
 category = "main"
 optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
-"aws-cdk.aws-acmpca" = "1.143.0"
-"aws-cdk.aws-cloudwatch" = "1.143.0"
-"aws-cdk.aws-iam" = "1.143.0"
-"aws-cdk.aws-lambda" = "1.143.0"
-"aws-cdk.aws-route53" = "1.143.0"
-"aws-cdk.core" = "1.143.0"
+"aws-cdk.aws-cloudwatch" = "1.130.0"
+"aws-cdk.aws-iam" = "1.130.0"
+"aws-cdk.aws-lambda" = "1.130.0"
+"aws-cdk.aws-route53" = "1.130.0"
+"aws-cdk.core" = "1.130.0"
 constructs = ">=3.3.69,<4.0.0"
-jsii = ">=1.52.1,<2.0.0"
+jsii = ">=1.41.0,<2.0.0"
 publication = ">=0.0.3"
 
 [[package]]
 name = "aws-cdk.aws-cloudformation"
-version = "1.143.0"
+version = "1.130.0"
 description = "The CDK Construct Library for AWS::CloudFormation"
 category = "main"
 optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
-"aws-cdk.aws-iam" = "1.143.0"
-"aws-cdk.aws-lambda" = "1.143.0"
-"aws-cdk.aws-s3" = "1.143.0"
-"aws-cdk.aws-sns" = "1.143.0"
-"aws-cdk.core" = "1.143.0"
-"aws-cdk.cx-api" = "1.143.0"
+"aws-cdk.aws-iam" = "1.130.0"
+"aws-cdk.aws-lambda" = "1.130.0"
+"aws-cdk.aws-s3" = "1.130.0"
+"aws-cdk.aws-sns" = "1.130.0"
+"aws-cdk.core" = "1.130.0"
+"aws-cdk.cx-api" = "1.130.0"
 constructs = ">=3.3.69,<4.0.0"
-jsii = ">=1.52.1,<2.0.0"
+jsii = ">=1.41.0,<2.0.0"
 publication = ">=0.0.3"
 
 [[package]]
 name = "aws-cdk.aws-cloudwatch"
-version = "1.143.0"
+version = "1.130.0"
 description = "The CDK Construct Library for AWS::CloudWatch"
 category = "main"
 optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
-"aws-cdk.aws-iam" = "1.143.0"
-"aws-cdk.core" = "1.143.0"
+"aws-cdk.aws-iam" = "1.130.0"
+"aws-cdk.core" = "1.130.0"
 constructs = ">=3.3.69,<4.0.0"
-jsii = ">=1.52.1,<2.0.0"
+jsii = ">=1.41.0,<2.0.0"
 publication = ">=0.0.3"
 
 [[package]]
 name = "aws-cdk.aws-codeguruprofiler"
-version = "1.143.0"
+version = "1.130.0"
 description = "The CDK Construct Library for AWS::CodeGuruProfiler"
 category = "main"
 optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
-"aws-cdk.aws-iam" = "1.143.0"
-"aws-cdk.core" = "1.143.0"
+"aws-cdk.aws-iam" = "1.130.0"
+"aws-cdk.core" = "1.130.0"
 constructs = ">=3.3.69,<4.0.0"
-jsii = ">=1.52.1,<2.0.0"
+jsii = ">=1.41.0,<2.0.0"
 publication = ">=0.0.3"
 
 [[package]]
 name = "aws-cdk.aws-codestarnotifications"
-version = "1.143.0"
+version = "1.130.0"
 description = "The CDK Construct Library for AWS::CodeStarNotifications"
 category = "main"
 optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
-"aws-cdk.core" = "1.143.0"
+"aws-cdk.core" = "1.130.0"
 constructs = ">=3.3.69,<4.0.0"
-jsii = ">=1.52.1,<2.0.0"
+jsii = ">=1.41.0,<2.0.0"
 publication = ">=0.0.3"
 
 [[package]]
 name = "aws-cdk.aws-ec2"
-version = "1.143.0"
+version = "1.130.0"
 description = "The CDK Construct Library for AWS::EC2"
 category = "main"
 optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
-"aws-cdk.aws-cloudwatch" = "1.143.0"
-"aws-cdk.aws-iam" = "1.143.0"
-"aws-cdk.aws-kms" = "1.143.0"
-"aws-cdk.aws-logs" = "1.143.0"
-"aws-cdk.aws-s3" = "1.143.0"
-"aws-cdk.aws-s3-assets" = "1.143.0"
-"aws-cdk.aws-ssm" = "1.143.0"
-"aws-cdk.cloud-assembly-schema" = "1.143.0"
-"aws-cdk.core" = "1.143.0"
-"aws-cdk.cx-api" = "1.143.0"
-"aws-cdk.region-info" = "1.143.0"
+"aws-cdk.aws-cloudwatch" = "1.130.0"
+"aws-cdk.aws-iam" = "1.130.0"
+"aws-cdk.aws-kms" = "1.130.0"
+"aws-cdk.aws-logs" = "1.130.0"
+"aws-cdk.aws-s3" = "1.130.0"
+"aws-cdk.aws-s3-assets" = "1.130.0"
+"aws-cdk.aws-ssm" = "1.130.0"
+"aws-cdk.cloud-assembly-schema" = "1.130.0"
+"aws-cdk.core" = "1.130.0"
+"aws-cdk.cx-api" = "1.130.0"
+"aws-cdk.region-info" = "1.130.0"
 constructs = ">=3.3.69,<4.0.0"
-jsii = ">=1.52.1,<2.0.0"
+jsii = ">=1.41.0,<2.0.0"
 publication = ">=0.0.3"
 
 [[package]]
 name = "aws-cdk.aws-ecr"
-version = "1.143.0"
+version = "1.130.0"
 description = "The CDK Construct Library for AWS::ECR"
 category = "main"
 optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
-"aws-cdk.aws-events" = "1.143.0"
-"aws-cdk.aws-iam" = "1.143.0"
-"aws-cdk.aws-kms" = "1.143.0"
-"aws-cdk.core" = "1.143.0"
+"aws-cdk.aws-events" = "1.130.0"
+"aws-cdk.aws-iam" = "1.130.0"
+"aws-cdk.core" = "1.130.0"
 constructs = ">=3.3.69,<4.0.0"
-jsii = ">=1.52.1,<2.0.0"
+jsii = ">=1.41.0,<2.0.0"
 publication = ">=0.0.3"
 
 [[package]]
 name = "aws-cdk.aws-ecr-assets"
-version = "1.143.0"
+version = "1.130.0"
 description = "Docker image assets deployed to ECR"
 category = "main"
 optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
-"aws-cdk.assets" = "1.143.0"
-"aws-cdk.aws-ecr" = "1.143.0"
-"aws-cdk.aws-iam" = "1.143.0"
-"aws-cdk.aws-s3" = "1.143.0"
-"aws-cdk.core" = "1.143.0"
-"aws-cdk.cx-api" = "1.143.0"
+"aws-cdk.assets" = "1.130.0"
+"aws-cdk.aws-ecr" = "1.130.0"
+"aws-cdk.aws-iam" = "1.130.0"
+"aws-cdk.aws-s3" = "1.130.0"
+"aws-cdk.core" = "1.130.0"
+"aws-cdk.cx-api" = "1.130.0"
 constructs = ">=3.3.69,<4.0.0"
-jsii = ">=1.52.1,<2.0.0"
+jsii = ">=1.41.0,<2.0.0"
 publication = ">=0.0.3"
 
 [[package]]
 name = "aws-cdk.aws-efs"
-version = "1.143.0"
+version = "1.130.0"
 description = "The CDK Construct Library for AWS::EFS"
 category = "main"
 optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
-"aws-cdk.aws-ec2" = "1.143.0"
-"aws-cdk.aws-iam" = "1.143.0"
-"aws-cdk.aws-kms" = "1.143.0"
-"aws-cdk.cloud-assembly-schema" = "1.143.0"
-"aws-cdk.core" = "1.143.0"
-"aws-cdk.cx-api" = "1.143.0"
+"aws-cdk.aws-ec2" = "1.130.0"
+"aws-cdk.aws-iam" = "1.130.0"
+"aws-cdk.aws-kms" = "1.130.0"
+"aws-cdk.cloud-assembly-schema" = "1.130.0"
+"aws-cdk.core" = "1.130.0"
+"aws-cdk.cx-api" = "1.130.0"
 constructs = ">=3.3.69,<4.0.0"
-jsii = ">=1.52.1,<2.0.0"
+jsii = ">=1.41.0,<2.0.0"
 publication = ">=0.0.3"
 
 [[package]]
 name = "aws-cdk.aws-events"
-version = "1.143.0"
+version = "1.130.0"
 description = "Amazon EventBridge Construct Library"
 category = "main"
 optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
-"aws-cdk.aws-iam" = "1.143.0"
-"aws-cdk.core" = "1.143.0"
+"aws-cdk.aws-iam" = "1.130.0"
+"aws-cdk.core" = "1.130.0"
 constructs = ">=3.3.69,<4.0.0"
-jsii = ">=1.52.1,<2.0.0"
+jsii = ">=1.41.0,<2.0.0"
 publication = ">=0.0.3"
 
 [[package]]
 name = "aws-cdk.aws-glue"
-version = "1.143.0"
+version = "1.130.0"
 description = "The CDK Construct Library for AWS::Glue"
 category = "main"
 optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
-"aws-cdk.assets" = "1.143.0"
-"aws-cdk.aws-cloudwatch" = "1.143.0"
-"aws-cdk.aws-ec2" = "1.143.0"
-"aws-cdk.aws-events" = "1.143.0"
-"aws-cdk.aws-iam" = "1.143.0"
-"aws-cdk.aws-kms" = "1.143.0"
-"aws-cdk.aws-logs" = "1.143.0"
-"aws-cdk.aws-s3" = "1.143.0"
-"aws-cdk.aws-s3-assets" = "1.143.0"
-"aws-cdk.core" = "1.143.0"
-"aws-cdk.custom-resources" = "1.143.0"
+"aws-cdk.assets" = "1.130.0"
+"aws-cdk.aws-cloudwatch" = "1.130.0"
+"aws-cdk.aws-ec2" = "1.130.0"
+"aws-cdk.aws-events" = "1.130.0"
+"aws-cdk.aws-iam" = "1.130.0"
+"aws-cdk.aws-kms" = "1.130.0"
+"aws-cdk.aws-logs" = "1.130.0"
+"aws-cdk.aws-s3" = "1.130.0"
+"aws-cdk.aws-s3-assets" = "1.130.0"
+"aws-cdk.core" = "1.130.0"
 constructs = ">=3.3.69,<4.0.0"
-jsii = ">=1.52.1,<2.0.0"
+jsii = ">=1.41.0,<2.0.0"
 publication = ">=0.0.3"
 
 [[package]]
 name = "aws-cdk.aws-iam"
-version = "1.143.0"
+version = "1.130.0"
 description = "CDK routines for easily assigning correct and minimal IAM permissions"
 category = "main"
 optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
-"aws-cdk.core" = "1.143.0"
-"aws-cdk.region-info" = "1.143.0"
+"aws-cdk.core" = "1.130.0"
+"aws-cdk.region-info" = "1.130.0"
 constructs = ">=3.3.69,<4.0.0"
-jsii = ">=1.52.1,<2.0.0"
+jsii = ">=1.41.0,<2.0.0"
 publication = ">=0.0.3"
 
 [[package]]
 name = "aws-cdk.aws-kms"
-version = "1.143.0"
+version = "1.130.0"
 description = "The CDK Construct Library for AWS::KMS"
 category = "main"
 optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
-"aws-cdk.aws-iam" = "1.143.0"
-"aws-cdk.cloud-assembly-schema" = "1.143.0"
-"aws-cdk.core" = "1.143.0"
-"aws-cdk.cx-api" = "1.143.0"
+"aws-cdk.aws-iam" = "1.130.0"
+"aws-cdk.cloud-assembly-schema" = "1.130.0"
+"aws-cdk.core" = "1.130.0"
+"aws-cdk.cx-api" = "1.130.0"
 constructs = ">=3.3.69,<4.0.0"
-jsii = ">=1.52.1,<2.0.0"
+jsii = ">=1.41.0,<2.0.0"
 publication = ">=0.0.3"
 
 [[package]]
 name = "aws-cdk.aws-lakeformation"
-version = "1.143.0"
+version = "1.130.0"
 description = "The CDK Construct Library for AWS::LakeFormation"
 category = "main"
 optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
-"aws-cdk.core" = "1.143.0"
+"aws-cdk.core" = "1.130.0"
 constructs = ">=3.3.69,<4.0.0"
-jsii = ">=1.52.1,<2.0.0"
+jsii = ">=1.41.0,<2.0.0"
 publication = ">=0.0.3"
 
 [[package]]
 name = "aws-cdk.aws-lambda"
-version = "1.143.0"
+version = "1.130.0"
 description = "The CDK Construct Library for AWS::Lambda"
 category = "main"
 optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
-"aws-cdk.aws-applicationautoscaling" = "1.143.0"
-"aws-cdk.aws-cloudwatch" = "1.143.0"
-"aws-cdk.aws-codeguruprofiler" = "1.143.0"
-"aws-cdk.aws-ec2" = "1.143.0"
-"aws-cdk.aws-ecr" = "1.143.0"
-"aws-cdk.aws-ecr-assets" = "1.143.0"
-"aws-cdk.aws-efs" = "1.143.0"
-"aws-cdk.aws-events" = "1.143.0"
-"aws-cdk.aws-iam" = "1.143.0"
-"aws-cdk.aws-kms" = "1.143.0"
-"aws-cdk.aws-logs" = "1.143.0"
-"aws-cdk.aws-s3" = "1.143.0"
-"aws-cdk.aws-s3-assets" = "1.143.0"
-"aws-cdk.aws-signer" = "1.143.0"
-"aws-cdk.aws-sqs" = "1.143.0"
-"aws-cdk.core" = "1.143.0"
-"aws-cdk.cx-api" = "1.143.0"
-"aws-cdk.region-info" = "1.143.0"
+"aws-cdk.aws-applicationautoscaling" = "1.130.0"
+"aws-cdk.aws-cloudwatch" = "1.130.0"
+"aws-cdk.aws-codeguruprofiler" = "1.130.0"
+"aws-cdk.aws-ec2" = "1.130.0"
+"aws-cdk.aws-ecr" = "1.130.0"
+"aws-cdk.aws-ecr-assets" = "1.130.0"
+"aws-cdk.aws-efs" = "1.130.0"
+"aws-cdk.aws-events" = "1.130.0"
+"aws-cdk.aws-iam" = "1.130.0"
+"aws-cdk.aws-kms" = "1.130.0"
+"aws-cdk.aws-logs" = "1.130.0"
+"aws-cdk.aws-s3" = "1.130.0"
+"aws-cdk.aws-s3-assets" = "1.130.0"
+"aws-cdk.aws-signer" = "1.130.0"
+"aws-cdk.aws-sqs" = "1.130.0"
+"aws-cdk.core" = "1.130.0"
+"aws-cdk.cx-api" = "1.130.0"
+"aws-cdk.region-info" = "1.130.0"
 constructs = ">=3.3.69,<4.0.0"
-jsii = ">=1.52.1,<2.0.0"
+jsii = ">=1.41.0,<2.0.0"
 publication = ">=0.0.3"
 
 [[package]]
 name = "aws-cdk.aws-logs"
-version = "1.143.0"
+version = "1.130.0"
 description = "The CDK Construct Library for AWS::Logs"
 category = "main"
 optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
-"aws-cdk.aws-cloudwatch" = "1.143.0"
-"aws-cdk.aws-iam" = "1.143.0"
-"aws-cdk.aws-kms" = "1.143.0"
-"aws-cdk.aws-s3-assets" = "1.143.0"
-"aws-cdk.core" = "1.143.0"
-"aws-cdk.cx-api" = "1.143.0"
+"aws-cdk.aws-cloudwatch" = "1.130.0"
+"aws-cdk.aws-iam" = "1.130.0"
+"aws-cdk.aws-kms" = "1.130.0"
+"aws-cdk.aws-s3-assets" = "1.130.0"
+"aws-cdk.core" = "1.130.0"
 constructs = ">=3.3.69,<4.0.0"
-jsii = ">=1.52.1,<2.0.0"
+jsii = ">=1.41.0,<2.0.0"
 publication = ">=0.0.3"
 
 [[package]]
 name = "aws-cdk.aws-opensearchservice"
-version = "1.143.0"
+version = "1.130.0"
 description = "The CDK Construct Library for AWS::OpenSearchService"
 category = "main"
 optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
-"aws-cdk.aws-certificatemanager" = "1.143.0"
-"aws-cdk.aws-cloudwatch" = "1.143.0"
-"aws-cdk.aws-ec2" = "1.143.0"
-"aws-cdk.aws-iam" = "1.143.0"
-"aws-cdk.aws-kms" = "1.143.0"
-"aws-cdk.aws-logs" = "1.143.0"
-"aws-cdk.aws-route53" = "1.143.0"
-"aws-cdk.aws-secretsmanager" = "1.143.0"
-"aws-cdk.core" = "1.143.0"
-"aws-cdk.custom-resources" = "1.143.0"
+"aws-cdk.aws-certificatemanager" = "1.130.0"
+"aws-cdk.aws-cloudwatch" = "1.130.0"
+"aws-cdk.aws-ec2" = "1.130.0"
+"aws-cdk.aws-iam" = "1.130.0"
+"aws-cdk.aws-kms" = "1.130.0"
+"aws-cdk.aws-logs" = "1.130.0"
+"aws-cdk.aws-route53" = "1.130.0"
+"aws-cdk.aws-secretsmanager" = "1.130.0"
+"aws-cdk.core" = "1.130.0"
+"aws-cdk.custom-resources" = "1.130.0"
 constructs = ">=3.3.69,<4.0.0"
-jsii = ">=1.52.1,<2.0.0"
+jsii = ">=1.41.0,<2.0.0"
 publication = ">=0.0.3"
 
 [[package]]
 name = "aws-cdk.aws-rds"
-version = "1.143.0"
+version = "1.130.0"
 description = "The CDK Construct Library for AWS::RDS"
 category = "main"
 optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
-"aws-cdk.aws-cloudwatch" = "1.143.0"
-"aws-cdk.aws-ec2" = "1.143.0"
-"aws-cdk.aws-events" = "1.143.0"
-"aws-cdk.aws-iam" = "1.143.0"
-"aws-cdk.aws-kms" = "1.143.0"
-"aws-cdk.aws-logs" = "1.143.0"
-"aws-cdk.aws-s3" = "1.143.0"
-"aws-cdk.aws-secretsmanager" = "1.143.0"
-"aws-cdk.core" = "1.143.0"
-"aws-cdk.cx-api" = "1.143.0"
+"aws-cdk.aws-cloudwatch" = "1.130.0"
+"aws-cdk.aws-ec2" = "1.130.0"
+"aws-cdk.aws-events" = "1.130.0"
+"aws-cdk.aws-iam" = "1.130.0"
+"aws-cdk.aws-kms" = "1.130.0"
+"aws-cdk.aws-logs" = "1.130.0"
+"aws-cdk.aws-s3" = "1.130.0"
+"aws-cdk.aws-secretsmanager" = "1.130.0"
+"aws-cdk.core" = "1.130.0"
+"aws-cdk.cx-api" = "1.130.0"
 constructs = ">=3.3.69,<4.0.0"
-jsii = ">=1.52.1,<2.0.0"
+jsii = ">=1.41.0,<2.0.0"
 publication = ">=0.0.3"
 
 [[package]]
 name = "aws-cdk.aws-redshift"
-version = "1.143.0"
+version = "1.130.0"
 description = "The CDK Construct Library for AWS::Redshift"
 category = "main"
 optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
-"aws-cdk.aws-ec2" = "1.143.0"
-"aws-cdk.aws-iam" = "1.143.0"
-"aws-cdk.aws-kms" = "1.143.0"
-"aws-cdk.aws-lambda" = "1.143.0"
-"aws-cdk.aws-s3" = "1.143.0"
-"aws-cdk.aws-secretsmanager" = "1.143.0"
-"aws-cdk.core" = "1.143.0"
-"aws-cdk.custom-resources" = "1.143.0"
+"aws-cdk.aws-ec2" = "1.130.0"
+"aws-cdk.aws-iam" = "1.130.0"
+"aws-cdk.aws-kms" = "1.130.0"
+"aws-cdk.aws-lambda" = "1.130.0"
+"aws-cdk.aws-s3" = "1.130.0"
+"aws-cdk.aws-secretsmanager" = "1.130.0"
+"aws-cdk.core" = "1.130.0"
+"aws-cdk.custom-resources" = "1.130.0"
 constructs = ">=3.3.69,<4.0.0"
-jsii = ">=1.52.1,<2.0.0"
+jsii = ">=1.41.0,<2.0.0"
 publication = ">=0.0.3"
 
 [[package]]
 name = "aws-cdk.aws-route53"
-version = "1.143.0"
+version = "1.130.0"
 description = "The CDK Construct Library for AWS::Route53"
 category = "main"
 optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
-"aws-cdk.aws-ec2" = "1.143.0"
-"aws-cdk.aws-iam" = "1.143.0"
-"aws-cdk.aws-logs" = "1.143.0"
-"aws-cdk.cloud-assembly-schema" = "1.143.0"
-"aws-cdk.core" = "1.143.0"
-"aws-cdk.custom-resources" = "1.143.0"
+"aws-cdk.aws-ec2" = "1.130.0"
+"aws-cdk.aws-iam" = "1.130.0"
+"aws-cdk.aws-logs" = "1.130.0"
+"aws-cdk.cloud-assembly-schema" = "1.130.0"
+"aws-cdk.core" = "1.130.0"
+"aws-cdk.custom-resources" = "1.130.0"
 constructs = ">=3.3.69,<4.0.0"
-jsii = ">=1.52.1,<2.0.0"
+jsii = ">=1.41.0,<2.0.0"
 publication = ">=0.0.3"
 
 [[package]]
 name = "aws-cdk.aws-s3"
-version = "1.143.0"
+version = "1.130.0"
 description = "The CDK Construct Library for AWS::S3"
 category = "main"
 optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
-"aws-cdk.aws-events" = "1.143.0"
-"aws-cdk.aws-iam" = "1.143.0"
-"aws-cdk.aws-kms" = "1.143.0"
-"aws-cdk.core" = "1.143.0"
-"aws-cdk.cx-api" = "1.143.0"
+"aws-cdk.aws-events" = "1.130.0"
+"aws-cdk.aws-iam" = "1.130.0"
+"aws-cdk.aws-kms" = "1.130.0"
+"aws-cdk.core" = "1.130.0"
+"aws-cdk.cx-api" = "1.130.0"
 constructs = ">=3.3.69,<4.0.0"
-jsii = ">=1.52.1,<2.0.0"
+jsii = ">=1.41.0,<2.0.0"
 publication = ">=0.0.3"
 
 [[package]]
 name = "aws-cdk.aws-s3-assets"
-version = "1.143.0"
+version = "1.130.0"
 description = "Deploy local files and directories to S3"
 category = "main"
 optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
-"aws-cdk.assets" = "1.143.0"
-"aws-cdk.aws-iam" = "1.143.0"
-"aws-cdk.aws-kms" = "1.143.0"
-"aws-cdk.aws-s3" = "1.143.0"
-"aws-cdk.core" = "1.143.0"
-"aws-cdk.cx-api" = "1.143.0"
+"aws-cdk.assets" = "1.130.0"
+"aws-cdk.aws-iam" = "1.130.0"
+"aws-cdk.aws-kms" = "1.130.0"
+"aws-cdk.aws-s3" = "1.130.0"
+"aws-cdk.core" = "1.130.0"
+"aws-cdk.cx-api" = "1.130.0"
 constructs = ">=3.3.69,<4.0.0"
-jsii = ">=1.52.1,<2.0.0"
+jsii = ">=1.41.0,<2.0.0"
 publication = ">=0.0.3"
 
 [[package]]
 name = "aws-cdk.aws-sam"
-version = "1.143.0"
+version = "1.130.0"
 description = "The CDK Construct Library for the AWS Serverless Application Model (SAM) resources"
 category = "main"
 optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
-"aws-cdk.core" = "1.143.0"
+"aws-cdk.core" = "1.130.0"
 constructs = ">=3.3.69,<4.0.0"
-jsii = ">=1.52.1,<2.0.0"
+jsii = ">=1.41.0,<2.0.0"
 publication = ">=0.0.3"
 
 [[package]]
 name = "aws-cdk.aws-secretsmanager"
-version = "1.143.0"
+version = "1.130.0"
 description = "The CDK Construct Library for AWS::SecretsManager"
 category = "main"
 optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
-"aws-cdk.aws-ec2" = "1.143.0"
-"aws-cdk.aws-iam" = "1.143.0"
-"aws-cdk.aws-kms" = "1.143.0"
-"aws-cdk.aws-lambda" = "1.143.0"
-"aws-cdk.aws-sam" = "1.143.0"
-"aws-cdk.core" = "1.143.0"
-"aws-cdk.cx-api" = "1.143.0"
+"aws-cdk.aws-ec2" = "1.130.0"
+"aws-cdk.aws-iam" = "1.130.0"
+"aws-cdk.aws-kms" = "1.130.0"
+"aws-cdk.aws-lambda" = "1.130.0"
+"aws-cdk.aws-sam" = "1.130.0"
+"aws-cdk.core" = "1.130.0"
+"aws-cdk.cx-api" = "1.130.0"
 constructs = ">=3.3.69,<4.0.0"
-jsii = ">=1.52.1,<2.0.0"
+jsii = ">=1.41.0,<2.0.0"
 publication = ">=0.0.3"
 
 [[package]]
 name = "aws-cdk.aws-signer"
-version = "1.143.0"
+version = "1.130.0"
 description = "The CDK Construct Library for AWS::Signer"
 category = "main"
 optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
-"aws-cdk.core" = "1.143.0"
+"aws-cdk.core" = "1.130.0"
 constructs = ">=3.3.69,<4.0.0"
-jsii = ">=1.52.1,<2.0.0"
+jsii = ">=1.41.0,<2.0.0"
 publication = ">=0.0.3"
 
 [[package]]
 name = "aws-cdk.aws-sns"
-version = "1.143.0"
+version = "1.130.0"
 description = "The CDK Construct Library for AWS::SNS"
 category = "main"
 optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
-"aws-cdk.aws-cloudwatch" = "1.143.0"
-"aws-cdk.aws-codestarnotifications" = "1.143.0"
-"aws-cdk.aws-events" = "1.143.0"
-"aws-cdk.aws-iam" = "1.143.0"
-"aws-cdk.aws-kms" = "1.143.0"
-"aws-cdk.aws-sqs" = "1.143.0"
-"aws-cdk.core" = "1.143.0"
+"aws-cdk.aws-cloudwatch" = "1.130.0"
+"aws-cdk.aws-codestarnotifications" = "1.130.0"
+"aws-cdk.aws-events" = "1.130.0"
+"aws-cdk.aws-iam" = "1.130.0"
+"aws-cdk.aws-kms" = "1.130.0"
+"aws-cdk.aws-sqs" = "1.130.0"
+"aws-cdk.core" = "1.130.0"
 constructs = ">=3.3.69,<4.0.0"
-jsii = ">=1.52.1,<2.0.0"
+jsii = ">=1.41.0,<2.0.0"
 publication = ">=0.0.3"
 
 [[package]]
 name = "aws-cdk.aws-sqs"
-version = "1.143.0"
+version = "1.130.0"
 description = "The CDK Construct Library for AWS::SQS"
 category = "main"
 optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
-"aws-cdk.aws-cloudwatch" = "1.143.0"
-"aws-cdk.aws-iam" = "1.143.0"
-"aws-cdk.aws-kms" = "1.143.0"
-"aws-cdk.core" = "1.143.0"
+"aws-cdk.aws-cloudwatch" = "1.130.0"
+"aws-cdk.aws-iam" = "1.130.0"
+"aws-cdk.aws-kms" = "1.130.0"
+"aws-cdk.core" = "1.130.0"
 constructs = ">=3.3.69,<4.0.0"
-jsii = ">=1.52.1,<2.0.0"
+jsii = ">=1.41.0,<2.0.0"
 publication = ">=0.0.3"
 
 [[package]]
 name = "aws-cdk.aws-ssm"
-version = "1.143.0"
+version = "1.130.0"
 description = "The CDK Construct Library for AWS::SSM"
 category = "main"
 optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
-"aws-cdk.aws-iam" = "1.143.0"
-"aws-cdk.aws-kms" = "1.143.0"
-"aws-cdk.cloud-assembly-schema" = "1.143.0"
-"aws-cdk.core" = "1.143.0"
+"aws-cdk.aws-iam" = "1.130.0"
+"aws-cdk.aws-kms" = "1.130.0"
+"aws-cdk.cloud-assembly-schema" = "1.130.0"
+"aws-cdk.core" = "1.130.0"
 constructs = ">=3.3.69,<4.0.0"
-jsii = ">=1.52.1,<2.0.0"
+jsii = ">=1.41.0,<2.0.0"
 publication = ">=0.0.3"
 
 [[package]]
 name = "aws-cdk.cloud-assembly-schema"
-version = "1.143.0"
+version = "1.130.0"
 description = "Cloud Assembly Schema"
 category = "main"
 optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
-jsii = ">=1.52.1,<2.0.0"
+jsii = ">=1.41.0,<2.0.0"
 publication = ">=0.0.3"
 
 [[package]]
 name = "aws-cdk.core"
-version = "1.143.0"
+version = "1.130.0"
 description = "AWS Cloud Development Kit Core Library"
 category = "main"
 optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
-"aws-cdk.cloud-assembly-schema" = "1.143.0"
-"aws-cdk.cx-api" = "1.143.0"
-"aws-cdk.region-info" = "1.143.0"
+"aws-cdk.cloud-assembly-schema" = "1.130.0"
+"aws-cdk.cx-api" = "1.130.0"
+"aws-cdk.region-info" = "1.130.0"
 constructs = ">=3.3.69,<4.0.0"
-jsii = ">=1.52.1,<2.0.0"
+jsii = ">=1.41.0,<2.0.0"
 publication = ">=0.0.3"
 
 [[package]]
 name = "aws-cdk.custom-resources"
-version = "1.143.0"
+version = "1.130.0"
 description = "Constructs for implementing CDK custom resources"
 category = "main"
 optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
-"aws-cdk.aws-cloudformation" = "1.143.0"
-"aws-cdk.aws-ec2" = "1.143.0"
-"aws-cdk.aws-iam" = "1.143.0"
-"aws-cdk.aws-lambda" = "1.143.0"
-"aws-cdk.aws-logs" = "1.143.0"
-"aws-cdk.aws-sns" = "1.143.0"
-"aws-cdk.core" = "1.143.0"
+"aws-cdk.aws-cloudformation" = "1.130.0"
+"aws-cdk.aws-ec2" = "1.130.0"
+"aws-cdk.aws-iam" = "1.130.0"
+"aws-cdk.aws-lambda" = "1.130.0"
+"aws-cdk.aws-logs" = "1.130.0"
+"aws-cdk.aws-sns" = "1.130.0"
+"aws-cdk.core" = "1.130.0"
 constructs = ">=3.3.69,<4.0.0"
-jsii = ">=1.52.1,<2.0.0"
+jsii = ">=1.41.0,<2.0.0"
 publication = ">=0.0.3"
 
 [[package]]
 name = "aws-cdk.cx-api"
-version = "1.143.0"
+version = "1.130.0"
 description = "Cloud executable protocol"
 category = "main"
 optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
-"aws-cdk.cloud-assembly-schema" = "1.143.0"
-jsii = ">=1.52.1,<2.0.0"
+"aws-cdk.cloud-assembly-schema" = "1.130.0"
+jsii = ">=1.41.0,<2.0.0"
 publication = ">=0.0.3"
 
 [[package]]
 name = "aws-cdk.region-info"
-version = "1.143.0"
+version = "1.130.0"
 description = "AWS region information, such as service principal names"
 category = "main"
 optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
-jsii = ">=1.52.1,<2.0.0"
+jsii = ">=1.41.0,<2.0.0"
 publication = ">=0.0.3"
 
 [[package]]
@@ -683,7 +665,7 @@ dev = ["bumpversion", "wheel", "watchdog", "flake8", "tox", "coverage", "sphinx"
 
 [[package]]
 name = "cattrs"
-version = "1.10.0"
+version = "1.8.0"
 description = "Composable complex class support for attrs and dataclasses."
 category = "main"
 optional = false
@@ -691,18 +673,17 @@ python-versions = ">=3.7,<4.0"
 
 [package.dependencies]
 attrs = ">=20"
-typing_extensions = {version = "*", markers = "python_version >= \"3.7\" and python_version < \"3.8\""}
 
 [[package]]
 name = "constructs"
-version = "3.3.211"
+version = "3.3.161"
 description = "A programming model for composable configuration"
 category = "main"
 optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
-jsii = ">=1.52.1,<2.0.0"
+jsii = ">=1.37.0,<2.0.0"
 publication = ">=0.0.3"
 
 [[package]]
@@ -722,7 +703,7 @@ testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-
 
 [[package]]
 name = "jsii"
-version = "1.52.1"
+version = "1.42.0"
 description = "Python client for jsii runtime"
 category = "main"
 optional = false
@@ -732,11 +713,11 @@ python-versions = "~=3.6"
 attrs = ">=21.2,<22.0"
 cattrs = [
     {version = ">=1.0.0,<1.1.0", markers = "python_version < \"3.7\""},
-    {version = ">=1.8,<1.11", markers = "python_version >= \"3.7\""},
+    {version = ">=1.8.0,<1.9.0", markers = "python_version >= \"3.7\""},
 ]
 importlib-resources = {version = "*", markers = "python_version < \"3.7\""}
 python-dateutil = "*"
-typing-extensions = ">=3.7,<5.0"
+typing-extensions = ">=3.7,<4.0"
 
 [[package]]
 name = "publication"
@@ -767,11 +748,11 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
 
 [[package]]
 name = "typing-extensions"
-version = "4.0.1"
-description = "Backported and Experimental Type Hints for Python 3.6+"
+version = "3.10.0.2"
+description = "Backported and Experimental Type Hints for Python 3.5+"
 category = "main"
 optional = false
-python-versions = ">=3.6"
+python-versions = "*"
 
 [[package]]
 name = "zipp"
@@ -787,179 +768,175 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytes
 
 [metadata]
 lock-version = "1.1"
-python-versions = ">=3.6.2, <3.11"
-content-hash = "5a07613f2b900e1d17d2a884287fd57a1590bc0ac6d335215dbb5f82819aac1e"
+python-versions = ">=3.6.2, <3.10"
+content-hash = "6d22ad86171a44206a94d9e9d051c12bb4caf0215a7af535ae5e7d371011afc1"
 
 [metadata.files]
 attrs = [
-    {file = "attrs-21.4.0-py2.py3-none-any.whl", hash = "sha256:2d27e3784d7a565d36ab851fe94887c5eccd6a463168875832a1be79c82828b4"},
-    {file = "attrs-21.4.0.tar.gz", hash = "sha256:626ba8234211db98e869df76230a137c4c40a12d72445c45d5f5b716f076e2fd"},
+    {file = "attrs-21.2.0-py2.py3-none-any.whl", hash = "sha256:149e90d6d8ac20db7a955ad60cf0e6881a3f20d37096140088356da6c716b0b1"},
+    {file = "attrs-21.2.0.tar.gz", hash = "sha256:ef6aaac3ca6cd92904cdd0d83f629a15f18053ec84e6432106f7a4d04ae4f5fb"},
 ]
 "aws-cdk.assets" = [
-    {file = "aws-cdk.assets-1.143.0.tar.gz", hash = "sha256:180db4f9ff218356738c1c0eec7d23c1efd57d43949c231ba8ff255f895f4cd7"},
-    {file = "aws_cdk.assets-1.143.0-py3-none-any.whl", hash = "sha256:5ab25a3ab7d58dbbf9064233f37aeffedc392d47af960cbeb1f0d3d5203b7afb"},
-]
-"aws-cdk.aws-acmpca" = [
-    {file = "aws-cdk.aws-acmpca-1.143.0.tar.gz", hash = "sha256:9d333b29bcba89dda4778fd78d4813d5119af38bb92d949385f4e39d4b2a19cf"},
-    {file = "aws_cdk.aws_acmpca-1.143.0-py3-none-any.whl", hash = "sha256:96d77bd16e99331ebdfe4367b327a9467169cfa1eab6be94e01dfd61335d3143"},
+    {file = "aws-cdk.assets-1.130.0.tar.gz", hash = "sha256:89628550ecfd4f2b3713cc515c5937ee766cc68cd39fc65dc15095a4fc92140f"},
+    {file = "aws_cdk.assets-1.130.0-py3-none-any.whl", hash = "sha256:88ee75118c7b34506acac8a3390e0f6360227f95764749ecf0cb8160532fef8d"},
 ]
 "aws-cdk.aws-applicationautoscaling" = [
-    {file = "aws-cdk.aws-applicationautoscaling-1.143.0.tar.gz", hash = "sha256:8690023fe51f5a1ad8140213a9861c04d67ed95e1318cbb27024aaffc6941f7c"},
-    {file = "aws_cdk.aws_applicationautoscaling-1.143.0-py3-none-any.whl", hash = "sha256:3c1b2f53bcbf26f9272118628cccab774122916bb81f56bfa570ba237ad91bfe"},
+    {file = "aws-cdk.aws-applicationautoscaling-1.130.0.tar.gz", hash = "sha256:c60000e6a2b86392efcfb32066207cff19adbdbe0b68e1ee4281cf5b52255b29"},
+    {file = "aws_cdk.aws_applicationautoscaling-1.130.0-py3-none-any.whl", hash = "sha256:0bed99bbc03ae733450e03bd0c6b075fadc13ae0d9363fffa047e6de0d68be60"},
 ]
 "aws-cdk.aws-autoscaling-common" = [
-    {file = "aws-cdk.aws-autoscaling-common-1.143.0.tar.gz", hash = "sha256:9d8f27a0c094515c6d2ad405fc3490039b4f65d596ef9553bfa5cb7811f64526"},
-    {file = "aws_cdk.aws_autoscaling_common-1.143.0-py3-none-any.whl", hash = "sha256:507a458541c9e1053a37da3b52418b59ddb46cc66df7bd95586239660fb021c0"},
+    {file = "aws-cdk.aws-autoscaling-common-1.130.0.tar.gz", hash = "sha256:bdc5eee7f30163daf0a40b78e888d356da9815057153791daa6bc2b3d1288541"},
+    {file = "aws_cdk.aws_autoscaling_common-1.130.0-py3-none-any.whl", hash = "sha256:46bd7dffa2ff4bcb2c3ee86e4881d7994924f23f76b59fb346cbc48a7e5b90e4"},
 ]
 "aws-cdk.aws-certificatemanager" = [
-    {file = "aws-cdk.aws-certificatemanager-1.143.0.tar.gz", hash = "sha256:8f46b6d0d8d806517e1f4d8ef2e06d9f70012d28ca9f337b1934368be9197ba5"},
-    {file = "aws_cdk.aws_certificatemanager-1.143.0-py3-none-any.whl", hash = "sha256:8d0399d2a25a27883c43c782ec4b793e5e37d77b85f22815d9669ef7efdb68ab"},
+    {file = "aws-cdk.aws-certificatemanager-1.130.0.tar.gz", hash = "sha256:e95cb1c48e5b37afa10ff0bdac0c0793d276f0c00d26140c6707a1fb0db74dc8"},
+    {file = "aws_cdk.aws_certificatemanager-1.130.0-py3-none-any.whl", hash = "sha256:23ceb0486f5e17ed230a651401ce9807faf3efffe793b0e1cef7e224f6ed25c9"},
 ]
 "aws-cdk.aws-cloudformation" = [
-    {file = "aws-cdk.aws-cloudformation-1.143.0.tar.gz", hash = "sha256:29549ccc068903456a5916f008fce2e0f93f5f24e22dc61db3850d1b9ce534ec"},
-    {file = "aws_cdk.aws_cloudformation-1.143.0-py3-none-any.whl", hash = "sha256:35f41457712be3e92b374fcfd4766c24cb166154b09a483fecad14f25358553c"},
+    {file = "aws-cdk.aws-cloudformation-1.130.0.tar.gz", hash = "sha256:c2176461dfd6bf46ad3143f9ca270e209e74d6a1f8d52e2260f4893b4b9ae228"},
+    {file = "aws_cdk.aws_cloudformation-1.130.0-py3-none-any.whl", hash = "sha256:0509fc5b6b6a6bae3752fe04a4b3f24776254e28bc5688238602b904852bd2ec"},
 ]
 "aws-cdk.aws-cloudwatch" = [
-    {file = "aws-cdk.aws-cloudwatch-1.143.0.tar.gz", hash = "sha256:ba87dad398e203710e6a03b6dbbe5cca899acb25d7c5b37d3ecf04ba237aa66b"},
-    {file = "aws_cdk.aws_cloudwatch-1.143.0-py3-none-any.whl", hash = "sha256:3401d03a3fc2881662faf3df7b622c7fe72724648620a96e292c541a169c111c"},
+    {file = "aws-cdk.aws-cloudwatch-1.130.0.tar.gz", hash = "sha256:1034ca75148e8292d014927911ba45cb18fad459371988ed32afd4b9de999449"},
+    {file = "aws_cdk.aws_cloudwatch-1.130.0-py3-none-any.whl", hash = "sha256:10cbd1b7047267a6a1f566e7f1bfd1e85932a709bbca5419226d1b84b7e0a0ee"},
 ]
 "aws-cdk.aws-codeguruprofiler" = [
-    {file = "aws-cdk.aws-codeguruprofiler-1.143.0.tar.gz", hash = "sha256:bbd358dd1586ab41e689bfcd02d00a5989ce8310f35af063ab249af6778a55a1"},
-    {file = "aws_cdk.aws_codeguruprofiler-1.143.0-py3-none-any.whl", hash = "sha256:136f13714ade24bb10eb667496d1314fa4710c0bd93fe44efd3897c8a4e9d161"},
+    {file = "aws-cdk.aws-codeguruprofiler-1.130.0.tar.gz", hash = "sha256:b9d9473a3e052e3164759c3f1ee694b7fc9d604c92b4a3df36c31a1a92306917"},
+    {file = "aws_cdk.aws_codeguruprofiler-1.130.0-py3-none-any.whl", hash = "sha256:0462eb79554b407bed707eda3f840956ec81d442ddfad4a1e93da20c89152835"},
 ]
 "aws-cdk.aws-codestarnotifications" = [
-    {file = "aws-cdk.aws-codestarnotifications-1.143.0.tar.gz", hash = "sha256:332e3120002341bdc7b3314ec2fb0f5d81d75469a0f982e88f7765f2824bf456"},
-    {file = "aws_cdk.aws_codestarnotifications-1.143.0-py3-none-any.whl", hash = "sha256:432d992581ef961ccd2f3490d9b6d5fdcbe26a3236253a8496c143f7a81ecbee"},
+    {file = "aws-cdk.aws-codestarnotifications-1.130.0.tar.gz", hash = "sha256:3c7f66d4c377e4f509b2719be4a2b1ac6efdbc4ab416eb56947a57ddd9290e27"},
+    {file = "aws_cdk.aws_codestarnotifications-1.130.0-py3-none-any.whl", hash = "sha256:89b8a5374616e732475f374acb1f8b26de20721e0d939dda733f7135754848e3"},
 ]
 "aws-cdk.aws-ec2" = [
-    {file = "aws-cdk.aws-ec2-1.143.0.tar.gz", hash = "sha256:2b6b359ac99fd89f820744d0efd3f835fb0a8df6f3b82be201feb71e10bbcff4"},
-    {file = "aws_cdk.aws_ec2-1.143.0-py3-none-any.whl", hash = "sha256:9b6858dfed1b0207f810a35d73b2c0804c36f8722ac2f49d0225a20349defb06"},
+    {file = "aws-cdk.aws-ec2-1.130.0.tar.gz", hash = "sha256:e0220bc03d44ad4e7f04c8efacd65c52c32faeac3d62a752d114e5606c47a6c2"},
+    {file = "aws_cdk.aws_ec2-1.130.0-py3-none-any.whl", hash = "sha256:fde2b2252debcbdd309a74bf7f3c1b7aaa83a671511eb9f753105687e59cafc3"},
 ]
 "aws-cdk.aws-ecr" = [
-    {file = "aws-cdk.aws-ecr-1.143.0.tar.gz", hash = "sha256:50eb433cd4b948b75b67258a477d5239b5153252ed0ce5d541977053dd2c51a7"},
-    {file = "aws_cdk.aws_ecr-1.143.0-py3-none-any.whl", hash = "sha256:1189e3b587fccbedeb6858aeb6db55014b5c1f9e9b2476092e6cdcebd94ac768"},
+    {file = "aws-cdk.aws-ecr-1.130.0.tar.gz", hash = "sha256:0c3aad603cc3f8e7cf2901d9a1365fe5110ff46f7d739b89333691219b186b92"},
+    {file = "aws_cdk.aws_ecr-1.130.0-py3-none-any.whl", hash = "sha256:7a2f8720d2f23c3578979c53f486c66a8449e0fd8135c6e4f82d4bd653151ce9"},
 ]
 "aws-cdk.aws-ecr-assets" = [
-    {file = "aws-cdk.aws-ecr-assets-1.143.0.tar.gz", hash = "sha256:72d82b6540a53f154e403de4b987a56b7385f78bde0a9ed0fb6de9cc11ebde9d"},
-    {file = "aws_cdk.aws_ecr_assets-1.143.0-py3-none-any.whl", hash = "sha256:e8d386d9affabae669f49a98f2160369c1d9925bbf7576f0cf495f548e3f9b2e"},
+    {file = "aws-cdk.aws-ecr-assets-1.130.0.tar.gz", hash = "sha256:40ca779cde59bdc3fcd979385a2b87b8e5cb052e1a4ef76e43bd781458ea5ce3"},
+    {file = "aws_cdk.aws_ecr_assets-1.130.0-py3-none-any.whl", hash = "sha256:ddf5078a87529b4e5c2216bb71579fc0489b4dcdab6e7d5246dd1e1d10263e29"},
 ]
 "aws-cdk.aws-efs" = [
-    {file = "aws-cdk.aws-efs-1.143.0.tar.gz", hash = "sha256:332484cfaf0751c4385e75e410880d94bbca15994f2dfef490fc25a703a46b6c"},
-    {file = "aws_cdk.aws_efs-1.143.0-py3-none-any.whl", hash = "sha256:d4dd4a48d872c508b40992be11e715fe80189536618fcea8dc2e6702442183d7"},
+    {file = "aws-cdk.aws-efs-1.130.0.tar.gz", hash = "sha256:8ed017fe4599bbfaa03dac74aa41cded39984813c8a6b14e280896aed0c8a39a"},
+    {file = "aws_cdk.aws_efs-1.130.0-py3-none-any.whl", hash = "sha256:ccf15abb0711725620d478f7b53e58f2f6109b77f6c47c5878dc00d70e196827"},
 ]
 "aws-cdk.aws-events" = [
-    {file = "aws-cdk.aws-events-1.143.0.tar.gz", hash = "sha256:cd9f6f9a7875b967b4f722cfc727a2a926efe67c835f5799f935bd6694b4daa0"},
-    {file = "aws_cdk.aws_events-1.143.0-py3-none-any.whl", hash = "sha256:0be4ac64c8e30ce9aa545c410f94b006d4c891dc54584177597a0eaeacb0230a"},
+    {file = "aws-cdk.aws-events-1.130.0.tar.gz", hash = "sha256:6ee24457c50eeda8c9c241596cfa6b123bb50ea2138787fef3e4bb54e4b47f13"},
+    {file = "aws_cdk.aws_events-1.130.0-py3-none-any.whl", hash = "sha256:df91c72843d9734a49017040090b1615be41de020906a57e6c708d860e8a4139"},
 ]
 "aws-cdk.aws-glue" = [
-    {file = "aws-cdk.aws-glue-1.143.0.tar.gz", hash = "sha256:f71815faa5132f9fd0d353ae60fe81aaf8bb3cc5bdea2e61d1d673c342d38329"},
-    {file = "aws_cdk.aws_glue-1.143.0-py3-none-any.whl", hash = "sha256:0b276bac0ce76c4113d8d5d14190e8ead66054926b7ac70d6d85542fb67b5e5c"},
+    {file = "aws-cdk.aws-glue-1.130.0.tar.gz", hash = "sha256:4ddda00ad580ffe207f2241a3cc66ab6c5a225580a9daa6adcd03c3299017d9a"},
+    {file = "aws_cdk.aws_glue-1.130.0-py3-none-any.whl", hash = "sha256:93f136d74b866619bd3aec2086b5a2c2b930acfaad7cc23cfa2f0b2a2eb85f90"},
 ]
 "aws-cdk.aws-iam" = [
-    {file = "aws-cdk.aws-iam-1.143.0.tar.gz", hash = "sha256:c2f28afd1ea3b87c02a9da0c5719048ba32dd7b81740842d10c0d8cf585dd78d"},
-    {file = "aws_cdk.aws_iam-1.143.0-py3-none-any.whl", hash = "sha256:1b2d1ffa8538488249d6ed9efe54b85944fc30def92311c9f23625f665b9bd87"},
+    {file = "aws-cdk.aws-iam-1.130.0.tar.gz", hash = "sha256:d2bf02a2d3f2bd81c1b9598e7b4424b0dc0d4694b57338d7efac43a89fb6409c"},
+    {file = "aws_cdk.aws_iam-1.130.0-py3-none-any.whl", hash = "sha256:3a3272745da9363177ebd8b138f42ce9407439f909ed9177c226e584022f4ff0"},
 ]
 "aws-cdk.aws-kms" = [
-    {file = "aws-cdk.aws-kms-1.143.0.tar.gz", hash = "sha256:d6d5ff9a6262ab7772af181e04385264169f81cace70741a525af8f734bf4ecc"},
-    {file = "aws_cdk.aws_kms-1.143.0-py3-none-any.whl", hash = "sha256:5587021dd6d85414fe5ff71654512b9d98b53c3b58a3e97258806ff803791f22"},
+    {file = "aws-cdk.aws-kms-1.130.0.tar.gz", hash = "sha256:1ece4b6753b0271d9164b32c0c94919e2f2a587677b19c554c2a990b5b0803b7"},
+    {file = "aws_cdk.aws_kms-1.130.0-py3-none-any.whl", hash = "sha256:de50127ab5f5f3838b6e4e549696ccfcd2cf18f7edd50616f82b1a0ddcd10075"},
 ]
 "aws-cdk.aws-lakeformation" = [
-    {file = "aws-cdk.aws-lakeformation-1.143.0.tar.gz", hash = "sha256:e2b77b36bebe390c99c68ded8aa3c4fe1673702a3aba7e38b93502bdc3258e59"},
-    {file = "aws_cdk.aws_lakeformation-1.143.0-py3-none-any.whl", hash = "sha256:fddcbcc76d7c7df2587a68b0fbccec1d6197aa56a8add92398db7b6b139fe6c3"},
+    {file = "aws-cdk.aws-lakeformation-1.130.0.tar.gz", hash = "sha256:bdf37b0047ed48c4fa70c5a9398b596f278a73abf4b912b6eb289fa8aeb96ca7"},
+    {file = "aws_cdk.aws_lakeformation-1.130.0-py3-none-any.whl", hash = "sha256:5bcd04992577dc2b67d437e0d73b3367e3b57315859a5c9426f15501db049151"},
 ]
 "aws-cdk.aws-lambda" = [
-    {file = "aws-cdk.aws-lambda-1.143.0.tar.gz", hash = "sha256:c698a1f9d2e235f170a593c7735be957fa45089a556b211a112c5e1f7a1ad6f3"},
-    {file = "aws_cdk.aws_lambda-1.143.0-py3-none-any.whl", hash = "sha256:0beec57fde30d04070f4d788c89956e41466550e7c114599cd6f30ac8b6ee54c"},
+    {file = "aws-cdk.aws-lambda-1.130.0.tar.gz", hash = "sha256:c3ee7c637f1a590ead83e75803865f58c0c18193ff841d94b0a0b51ea1e9d6fb"},
+    {file = "aws_cdk.aws_lambda-1.130.0-py3-none-any.whl", hash = "sha256:6c8dec3aad5d3900888aab52b0a844d3c05e94f977ff04ec26083302cc76edc8"},
 ]
 "aws-cdk.aws-logs" = [
-    {file = "aws-cdk.aws-logs-1.143.0.tar.gz", hash = "sha256:ab1393000cdf9b6a9263ac4c2e079dc761cb6124a98adab04f9bd87e42240288"},
-    {file = "aws_cdk.aws_logs-1.143.0-py3-none-any.whl", hash = "sha256:4feed8b57b1e5be0272b836e38d211163f8b799d7a836a7b17ea400bc83f0108"},
+    {file = "aws-cdk.aws-logs-1.130.0.tar.gz", hash = "sha256:d022ec78f953f1276d710e903ee75857fe86a05b1f44f1610ac4d52b8652ddfc"},
+    {file = "aws_cdk.aws_logs-1.130.0-py3-none-any.whl", hash = "sha256:da8ff0e9ed334bb4bc34cac698ad46ae8e815c7e9018e3754c9a342b84f26bbb"},
 ]
 "aws-cdk.aws-opensearchservice" = [
-    {file = "aws-cdk.aws-opensearchservice-1.143.0.tar.gz", hash = "sha256:ea27a781249aaab879cedc92c2a7ce6feab6c9d8b78ecff174bff038ea6a784f"},
-    {file = "aws_cdk.aws_opensearchservice-1.143.0-py3-none-any.whl", hash = "sha256:bc4fca7e055d1cbe5b6c60e98688515f918150df5f8b8e12915f1d037ac1d660"},
+    {file = "aws-cdk.aws-opensearchservice-1.130.0.tar.gz", hash = "sha256:4194f91d28b50a4dc7b97d773871798a79bd93774146cfb8d2fe0ad30030328b"},
+    {file = "aws_cdk.aws_opensearchservice-1.130.0-py3-none-any.whl", hash = "sha256:b4bb3b0a80f883aeeae79417ef45c5fc1f46abd05dfa9c46bd02476d5083af39"},
 ]
 "aws-cdk.aws-rds" = [
-    {file = "aws-cdk.aws-rds-1.143.0.tar.gz", hash = "sha256:9cb153a9689b605e5794c181d2f5b0dbb04821b04a197498c2a7d467ea1e1aaf"},
-    {file = "aws_cdk.aws_rds-1.143.0-py3-none-any.whl", hash = "sha256:574338a376f499c860e968530a3ab2884ff139e9ca5ea68597163b595edd3d68"},
+    {file = "aws-cdk.aws-rds-1.130.0.tar.gz", hash = "sha256:316abaa5786703bf1459f538d8d1bcc02f5b4c75df320fe2e9d62821f92fa7f4"},
+    {file = "aws_cdk.aws_rds-1.130.0-py3-none-any.whl", hash = "sha256:a781ca1b945f655797f06106eb72142be4d1d6b9278e707a29a7e75d7e8dea73"},
 ]
 "aws-cdk.aws-redshift" = [
-    {file = "aws-cdk.aws-redshift-1.143.0.tar.gz", hash = "sha256:e163ca3405229909ae3929d1097d980ac815b24b3535259a2e0c7be27f5e894f"},
-    {file = "aws_cdk.aws_redshift-1.143.0-py3-none-any.whl", hash = "sha256:b89e792aeb73f4019ea607f083f002730205bde3792e6c3f6e8487969e2f6251"},
+    {file = "aws-cdk.aws-redshift-1.130.0.tar.gz", hash = "sha256:7447af727af2ff2014aad2d04a96ef70ffc6e65142d575dffb762cd147067e06"},
+    {file = "aws_cdk.aws_redshift-1.130.0-py3-none-any.whl", hash = "sha256:e60832a9a042eaeeb646769a40753a82b807dc1154df58c20d524010e361c5b0"},
 ]
 "aws-cdk.aws-route53" = [
-    {file = "aws-cdk.aws-route53-1.143.0.tar.gz", hash = "sha256:d5a29c0301d2fc3bf447b2676794bb10467a03c89e36254b54e123ef38191258"},
-    {file = "aws_cdk.aws_route53-1.143.0-py3-none-any.whl", hash = "sha256:ed25524b335735f606550078fb33602b0ffdde3767bd6abd074b83885755d587"},
+    {file = "aws-cdk.aws-route53-1.130.0.tar.gz", hash = "sha256:6d1a209505e794922718cbf2f8f432f8d51b305da63ad4f10008b8f1f535f526"},
+    {file = "aws_cdk.aws_route53-1.130.0-py3-none-any.whl", hash = "sha256:270877be4a1469f84c3022300baba2b982cd1644b4ea01d65fb0522adcf9b822"},
 ]
 "aws-cdk.aws-s3" = [
-    {file = "aws-cdk.aws-s3-1.143.0.tar.gz", hash = "sha256:4d50b5702dbb7ef61399fa43d7715cebb9f7eb4feb6646156a19754f8ca076c8"},
-    {file = "aws_cdk.aws_s3-1.143.0-py3-none-any.whl", hash = "sha256:ec01155c157d88ffd7c5eff0dc79fbadf87c8c6eddaf03e035f595e6d61a3651"},
+    {file = "aws-cdk.aws-s3-1.130.0.tar.gz", hash = "sha256:940bcb081783937e774cf4f44f77ba7a8211ebe9440cca2d7225b310f4272f79"},
+    {file = "aws_cdk.aws_s3-1.130.0-py3-none-any.whl", hash = "sha256:9fac2a150adf92700c05a02c603d0ff1185894235443980fafc874354c380f52"},
 ]
 "aws-cdk.aws-s3-assets" = [
-    {file = "aws-cdk.aws-s3-assets-1.143.0.tar.gz", hash = "sha256:2276f65b47cc1be42269a668a862567cb585070052ec6431489ce3a84d1abd02"},
-    {file = "aws_cdk.aws_s3_assets-1.143.0-py3-none-any.whl", hash = "sha256:4356df23315d53e6fbcf55a9f48fe0cff45a04d0141965e889ae8fcc37b032f2"},
+    {file = "aws-cdk.aws-s3-assets-1.130.0.tar.gz", hash = "sha256:db33b348222895ad14cb9d52d5582b1e80d0e9ff008f8c10ea912499ab7c14f1"},
+    {file = "aws_cdk.aws_s3_assets-1.130.0-py3-none-any.whl", hash = "sha256:01a5b0f2c759a88176929569c6f69d0efb8901452fe112cfd3b3f4782fec12ab"},
 ]
 "aws-cdk.aws-sam" = [
-    {file = "aws-cdk.aws-sam-1.143.0.tar.gz", hash = "sha256:3da84163060e27e1984243ca1e8a941fbc3639d74fe4bad47b83174666bcb8ad"},
-    {file = "aws_cdk.aws_sam-1.143.0-py3-none-any.whl", hash = "sha256:9cede0d9f3ed23cbb6d70cf8a0b2be1907cb8334067b7d9714b21ef1cc14a1ba"},
+    {file = "aws-cdk.aws-sam-1.130.0.tar.gz", hash = "sha256:564877af10684b99a76d7ae83b888f9dfc1f7894caed81d5349a059f51430836"},
+    {file = "aws_cdk.aws_sam-1.130.0-py3-none-any.whl", hash = "sha256:dbd38e5e52b5f94aff76bc18640e8ba11ae0d0b183867f747942c753935bf326"},
 ]
 "aws-cdk.aws-secretsmanager" = [
-    {file = "aws-cdk.aws-secretsmanager-1.143.0.tar.gz", hash = "sha256:e574d80016d0a9bb0595c5d3e73eb0f9b020714d0cb552fee81e8dcf2a37218c"},
-    {file = "aws_cdk.aws_secretsmanager-1.143.0-py3-none-any.whl", hash = "sha256:92faa27df7941dd824bb2d99039c9867d1a017ae34ad6b0587d2876a6059c497"},
+    {file = "aws-cdk.aws-secretsmanager-1.130.0.tar.gz", hash = "sha256:96e52bd3e6523b22f1d60aadeb0b6f435a5276a1ec794e4cfe2294f8ac26259a"},
+    {file = "aws_cdk.aws_secretsmanager-1.130.0-py3-none-any.whl", hash = "sha256:a929ef9fea760b37d5306a1ee9deeecbac2530ab2ea7ec1fc1085544e6af1ca0"},
 ]
 "aws-cdk.aws-signer" = [
-    {file = "aws-cdk.aws-signer-1.143.0.tar.gz", hash = "sha256:482ed38d13f8a5b9aab6c077d9f6bd958047be2be44fc9774eb6061c61dd4bd8"},
-    {file = "aws_cdk.aws_signer-1.143.0-py3-none-any.whl", hash = "sha256:6235fdcdc806df967b723be7c68e2f34a5af7b4e29271af3273f0b96af268af5"},
+    {file = "aws-cdk.aws-signer-1.130.0.tar.gz", hash = "sha256:f453d608a491dd0ff7d97fa597f17480d3bf43a0eaedd975e0846bf03de0ab0d"},
+    {file = "aws_cdk.aws_signer-1.130.0-py3-none-any.whl", hash = "sha256:10a5981156c83c8725f565931167b376db24c08d43b325a8ad0e4a10559b32df"},
 ]
 "aws-cdk.aws-sns" = [
-    {file = "aws-cdk.aws-sns-1.143.0.tar.gz", hash = "sha256:c46aea3292408634b28858402a90dcbe3407ccf6ae3c71abd3fef3414a01959f"},
-    {file = "aws_cdk.aws_sns-1.143.0-py3-none-any.whl", hash = "sha256:e2142cc9687b3a64b97488fae86faf5fd4f755858496e6e55d67e03a96d6ecf4"},
+    {file = "aws-cdk.aws-sns-1.130.0.tar.gz", hash = "sha256:a2494dd42513b870ef94c0f013e734473fb8a02042b21da5864e3b8bd6609963"},
+    {file = "aws_cdk.aws_sns-1.130.0-py3-none-any.whl", hash = "sha256:7b6dfc5c50cdc0005caac683731772502a9d26d6ef415256f21746bef0b7b444"},
 ]
 "aws-cdk.aws-sqs" = [
-    {file = "aws-cdk.aws-sqs-1.143.0.tar.gz", hash = "sha256:d68a26bdea6f95632a5bd62c326b6a60630ba546668e2fc5c5c2d6619261a610"},
-    {file = "aws_cdk.aws_sqs-1.143.0-py3-none-any.whl", hash = "sha256:e584e60c57f63343646a95bb1c81f1952dc6db7e33a483268a75d38584633277"},
+    {file = "aws-cdk.aws-sqs-1.130.0.tar.gz", hash = "sha256:baef9bfc74c33ad5e9ff65a4d48477f68fb503950d58d21e9cc657e8a9914c0f"},
+    {file = "aws_cdk.aws_sqs-1.130.0-py3-none-any.whl", hash = "sha256:bd40f528012fd38398dd7cc6a8c91c62da634e2e620ecfa6530ae43a5d1890b5"},
 ]
 "aws-cdk.aws-ssm" = [
-    {file = "aws-cdk.aws-ssm-1.143.0.tar.gz", hash = "sha256:c75e8bf4e59c1b6702a33ee74ae653cca622160f20668e8b18da44187a3211b1"},
-    {file = "aws_cdk.aws_ssm-1.143.0-py3-none-any.whl", hash = "sha256:51ea415268f5356509e952c903732fdb5f6194254e5d166719b1a3bf3d7513ad"},
+    {file = "aws-cdk.aws-ssm-1.130.0.tar.gz", hash = "sha256:2c0a2e400b82864233e76973020dc16e88afc35aa0ef4dd5250d0404e1236de0"},
+    {file = "aws_cdk.aws_ssm-1.130.0-py3-none-any.whl", hash = "sha256:dd84d306f4794433b921f75081d3db41dfe6fdc6078bfa377a096a1457adc9a9"},
 ]
 "aws-cdk.cloud-assembly-schema" = [
-    {file = "aws-cdk.cloud-assembly-schema-1.143.0.tar.gz", hash = "sha256:bb0c472de882f4864e931775499b94706e07f498ce470dd328153adcf5e451f7"},
-    {file = "aws_cdk.cloud_assembly_schema-1.143.0-py3-none-any.whl", hash = "sha256:a5bb94ed4d219d20784d26aa5b95bab93e61d44dc193c2f6d546b2854fae94b0"},
+    {file = "aws-cdk.cloud-assembly-schema-1.130.0.tar.gz", hash = "sha256:31231d1fa14037f2af0a0a27657c7e603103c876464868bb8a5731698dba9d7f"},
+    {file = "aws_cdk.cloud_assembly_schema-1.130.0-py3-none-any.whl", hash = "sha256:3eadde99a914ca53e101e66a403b554537435a29e1954cb13e94cdc9305da48a"},
 ]
 "aws-cdk.core" = [
-    {file = "aws-cdk.core-1.143.0.tar.gz", hash = "sha256:a2dfb118a0e3d6d89a0dd1f7ce165dcd1c5799248f079cf1232ef3dd0a5b8993"},
-    {file = "aws_cdk.core-1.143.0-py3-none-any.whl", hash = "sha256:0c62c3c8c53e16a4bde15168341282fb1cd57763d5753648b77fd49b9021c3f5"},
+    {file = "aws-cdk.core-1.130.0.tar.gz", hash = "sha256:d07b98dad35b18481e46b92b6fde7061b76730ac9d1111849db321e519ebdc52"},
+    {file = "aws_cdk.core-1.130.0-py3-none-any.whl", hash = "sha256:7b3f1d0e9f83263763694cfb814346c38984041226180fe298056670fa5a5bd9"},
 ]
 "aws-cdk.custom-resources" = [
-    {file = "aws-cdk.custom-resources-1.143.0.tar.gz", hash = "sha256:98a5c5974de0926b91eab1bd16b48c3ff9342941ef4e3080cae64b254174bd5b"},
-    {file = "aws_cdk.custom_resources-1.143.0-py3-none-any.whl", hash = "sha256:b9ab3f581ff53561d11e2e07a3bab8eb0a43eef51a7785287b0c62edf9d58c37"},
+    {file = "aws-cdk.custom-resources-1.130.0.tar.gz", hash = "sha256:c212447b64f79d3605db6e072d23acc6fa1135e5399162a8cd258bc1d22e03e2"},
+    {file = "aws_cdk.custom_resources-1.130.0-py3-none-any.whl", hash = "sha256:07c8a6c99bfe53d251303a7cf50b109fa974ddfd2fdbd22f3e94534271a2f666"},
 ]
 "aws-cdk.cx-api" = [
-    {file = "aws-cdk.cx-api-1.143.0.tar.gz", hash = "sha256:df35fa394bbb1f5ff416da3dccfa80d928b9781a14919e6b15b4db2fe060e6bf"},
-    {file = "aws_cdk.cx_api-1.143.0-py3-none-any.whl", hash = "sha256:ad225f6d10a51147d6a29cafdf87fde6a54836c539b222908a8073999bff3bc5"},
+    {file = "aws-cdk.cx-api-1.130.0.tar.gz", hash = "sha256:3640cdc3c34566bbd0f32fd899fd5ea969d266d0efcd14f67784e557d2c7192c"},
+    {file = "aws_cdk.cx_api-1.130.0-py3-none-any.whl", hash = "sha256:26b425e11e0718f531b6578e0621f141089ec1946ccfa124f929ae932f8340a6"},
 ]
 "aws-cdk.region-info" = [
-    {file = "aws-cdk.region-info-1.143.0.tar.gz", hash = "sha256:feb85ad58f4f4da7eced7d88853895246ab71a64156a13195b172dad920470d7"},
-    {file = "aws_cdk.region_info-1.143.0-py3-none-any.whl", hash = "sha256:3c1c450b6cae5926cbe5a3ae3dfefc25d88e8a3fad5000a68eafb0240f858bbd"},
+    {file = "aws-cdk.region-info-1.130.0.tar.gz", hash = "sha256:f5534c3c02cc25215cca2d74aee4dc70cd34b35d86550415a085db65851b135e"},
+    {file = "aws_cdk.region_info-1.130.0-py3-none-any.whl", hash = "sha256:2d4110779dd87f405270bfb31c73f315898698af04ec23b8069cc444d0bd896e"},
 ]
 cattrs = [
     {file = "cattrs-1.0.0-py2.py3-none-any.whl", hash = "sha256:616972ae3dfa6e623a40ad3cb845420e64942989152774ab055e5c2b2f89f997"},
     {file = "cattrs-1.0.0.tar.gz", hash = "sha256:b7ab5cf8ad127c42eefd01410c1c6e28569a45a255ea80ed968511873c433c7a"},
-    {file = "cattrs-1.10.0-py3-none-any.whl", hash = "sha256:35dd9063244263e63bd0bd24ea61e3015b00272cead084b2c40d788b0f857c46"},
-    {file = "cattrs-1.10.0.tar.gz", hash = "sha256:211800f725cdecedcbcf4c753bbd22d248312b37d130f06045434acb7d9b34e1"},
+    {file = "cattrs-1.8.0-py3-none-any.whl", hash = "sha256:901fb2040529ae8fc9d93f48a2cdf7de3e983312ffb2a164ffa4e9847f253af1"},
+    {file = "cattrs-1.8.0.tar.gz", hash = "sha256:5c121ab06a7cac494813c228721a7feb5a6423b17316eeaebf13f5a03e5b0d53"},
 ]
 constructs = [
-    {file = "constructs-3.3.211-py3-none-any.whl", hash = "sha256:222dd9467dd01b4db1cadfdd7d1aa4cdbc1e0bc195716151acc25347c238e1b1"},
-    {file = "constructs-3.3.211.tar.gz", hash = "sha256:302d881e970c624b2e967adc7b74337a95a90ab6b102caa2d366046adf9501cb"},
+    {file = "constructs-3.3.161-py3-none-any.whl", hash = "sha256:3215f2a3628584ad8e6a5ebabf4e1cc0b125367f2347e6fa0d9ccfd735ac2bbb"},
+    {file = "constructs-3.3.161.tar.gz", hash = "sha256:2b33c412ff0f1d21205d85f778e4594a35c9c98b65cb47fea7533fbe40de1730"},
 ]
 importlib-resources = [
     {file = "importlib_resources-5.4.0-py3-none-any.whl", hash = "sha256:33a95faed5fc19b4bc16b29a6eeae248a3fe69dd55d4d229d2b480e23eeaad45"},
     {file = "importlib_resources-5.4.0.tar.gz", hash = "sha256:d756e2f85dd4de2ba89be0b21dba2a3bbec2e871a42a3a16719258a11f87506b"},
 ]
 jsii = [
-    {file = "jsii-1.52.1-py3-none-any.whl", hash = "sha256:c1477f17275d62fbda28ea25c1f0a6cd1d95c1b73dda70835f33e34f0b70ac52"},
-    {file = "jsii-1.52.1.tar.gz", hash = "sha256:32f886e99c06a23943986e9580f553860aabeb91dc3a3520d5b76fef1e631c04"},
+    {file = "jsii-1.42.0-py3-none-any.whl", hash = "sha256:29a4c87c8e1ad7eb67b65b03775f37bdd2212088a1eb854e84f5b541b9eaceb4"},
+    {file = "jsii-1.42.0.tar.gz", hash = "sha256:44a1874464c3c9b48417523d5a4790ee792dab6e6f522bc6e6e2c84e42417323"},
 ]
 publication = [
     {file = "publication-0.0.3-py2.py3-none-any.whl", hash = "sha256:0248885351febc11d8a1098d5c8e3ab2dabcf3e8c0c96db1e17ecd12b53afbe6"},
@@ -974,8 +951,9 @@ six = [
     {file = "six-1.16.0.tar.gz", hash = "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"},
 ]
 typing-extensions = [
-    {file = "typing_extensions-4.0.1-py3-none-any.whl", hash = "sha256:7f001e5ac290a0c0401508864c7ec868be4e701886d5b573a9528ed3973d9d3b"},
-    {file = "typing_extensions-4.0.1.tar.gz", hash = "sha256:4ca091dea149f945ec56afb48dae714f21e8692ef22a395223bcd328961b6a0e"},
+    {file = "typing_extensions-3.10.0.2-py2-none-any.whl", hash = "sha256:d8226d10bc02a29bcc81df19a26e56a9647f8b0a6d4a83924139f4a8b01f17b7"},
+    {file = "typing_extensions-3.10.0.2-py3-none-any.whl", hash = "sha256:f1d25edafde516b146ecd0613dabcc61409817af4766fbbcfb8d1ad4ec441a34"},
+    {file = "typing_extensions-3.10.0.2.tar.gz", hash = "sha256:49f75d16ff11f1cd258e1b988ccff82a3ca5570217d7ad8c5f48205dd99a677e"},
 ]
 zipp = [
     {file = "zipp-3.6.0-py3-none-any.whl", hash = "sha256:9fe5ea21568a0a70e50f273397638d39b03353731e6cbbb3fd8502a33fec40bc"},

--- a/tests/test_redshift.py
+++ b/tests/test_redshift.py
@@ -751,6 +751,14 @@ def test_get_paths_from_manifest(path):
     assert len(paths) == 3
 
 
+def test_get_paths_from_manifest_type_exception(path):
+
+    with pytest.raises(TypeError):
+        wr.redshift._get_paths_from_manifest(
+            path=[],
+        )
+
+
 def test_copy_from_files_manifest(path, redshift_table, redshift_con, databases_parameters):
     df = get_df_category().drop(["binary"], axis=1, inplace=False)
     wr.s3.to_parquet(df, f"{path}test.parquet")

--- a/tests/test_redshift.py
+++ b/tests/test_redshift.py
@@ -751,14 +751,6 @@ def test_get_paths_from_manifest(path):
     assert len(paths) == 3
 
 
-def test_get_paths_from_manifest_type_exception(path):
-
-    with pytest.raises(TypeError):
-        wr.redshift._get_paths_from_manifest(
-            path=[],
-        )
-
-
 def test_copy_from_files_manifest(path, redshift_table, redshift_con, databases_parameters):
     df = get_df_category().drop(["binary"], axis=1, inplace=False)
     wr.s3.to_parquet(df, f"{path}test.parquet")

--- a/tests/test_redshift.py
+++ b/tests/test_redshift.py
@@ -765,7 +765,6 @@ def test_copy_from_files_manifest(path, redshift_table, redshift_con, databases_
     )
     wr.redshift.copy_from_files(
         path=f"{path}manifest.json",
-        path_suffix=[".parquet"],
         con=redshift_con,
         table=redshift_table,
         schema="public",


### PR DESCRIPTION
Subject: Adding manifest parameter to 'copy_from_files 'method

### Feature
- Feature


### Detail
- New parameter for `redshift.copy_from_files(...)` : `manifest`
- New method `redshift._get_paths_from_manifest(...)`: Returns list of S3 paths declared in manifest file.

### Relates
- [#1142 ](https://github.com/awslabs/aws-data-wrangler/issues/1142)

- By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.


### Validation 
- Unit test written for method using new parameter.
```
> pytest tests/test_redshift.py::test_copy_from_files_manifest
============================================================================== test session starts ===============================================================================
platform darwin -- Python 3.7.7, pytest-6.2.5, py-1.11.0, pluggy-1.0.0 -- /Users/hansonlu/work/awslabs/code/github/aws-data-wrangler/.venv/bin/python
cachedir: .pytest_cache
rootdir: /Users/hansonlu/work/awslabs/code/github/aws-data-wrangler, configfile: pyproject.toml
plugins: xdist-2.5.0, anyio-3.5.0, forked-1.4.0, timeout-2.1.0, rerunfailures-10.2, cov-3.0.0
collected 1 item

tests/test_redshift.py::test_copy_from_files_manifest PASSED                                                                                                               [100%]

=============================================================================== 1 passed in 5.14s ================================================================================
```

- Unit test written for new method: `_get_paths_from_manifest(...)`
```
> pytest tests/test_redshift.py::test_get_paths_from_manifest
============================================================================== test session starts ===============================================================================
platform darwin -- Python 3.7.7, pytest-6.2.5, py-1.11.0, pluggy-1.0.0 -- /Users/hansonlu/work/awslabs/code/github/aws-data-wrangler/.venv/bin/python
cachedir: .pytest_cache
rootdir: /Users/hansonlu/work/awslabs/code/github/aws-data-wrangler, configfile: pyproject.toml
plugins: xdist-2.5.0, anyio-3.5.0, forked-1.4.0, timeout-2.1.0, rerunfailures-10.2, cov-3.0.0
collected 1 item

tests/test_redshift.py::test_get_paths_from_manifest PASSED                                                                                                                [100%]

=============================================================================== 1 passed in 1.66s ================================================================================

```
