### PR TITLE
BugFix: allow decimal values within struct when writing to parquet

### DIFF
--- a/awswrangler/_data_types.py
+++ b/awswrangler/_data_types.py
@@ -234,9 +234,9 @@ def _split_fields(s: str) -> Iterator[str]:
     counter: int = 0
     last: int = 0
     for i, x in enumerate(s):
-        if x == "<":
+        if x in ("<", "("):
             counter += 1
-        elif x == ">":
+        elif x in (">", ")"):
             counter -= 1
         elif x == "," and counter == 0:
             yield s[last:i]


### PR DESCRIPTION
When providing a schema and writing to parquet, nested decimal values within a struct are not parsed correctly by the `_split_fields` function. The format for a decimal declaration is `decimal(precision, scale)` however the `_split_fields` functions chops the declaration in half at the comma resulting in the error when parsing the decimal value.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
