### PR TITLE
Add Athena get_named_query_statement method

### DIFF
--- a/awswrangler/athena/__init__.py
+++ b/awswrangler/athena/__init__.py
@@ -4,6 +4,7 @@ from awswrangler.athena._read import read_sql_query, read_sql_table, unload  # n
 from awswrangler.athena._utils import (  # noqa
     create_athena_bucket,
     describe_table,
+    get_named_query_statement,
     get_query_columns_types,
     get_query_execution,
     get_work_group,
@@ -21,6 +22,7 @@ __all__ = [
     "describe_table",
     "get_query_columns_types",
     "get_query_execution",
+    "get_named_query_statement",
     "get_work_group",
     "repair_table",
     "show_create_table",

--- a/awswrangler/athena/_read.py
+++ b/awswrangler/athena/_read.py
@@ -774,7 +774,7 @@ def read_sql_query(
     kms_key : str, optional
         For SSE-KMS, this is the KMS key ARN or ID.
     keep_files : bool
-        Should Wrangler delete or keep the staging files produced by Athena?
+        Whether staging files produced by Athena are retained. 'True' by default.
     ctas_database_name : str, optional
         The name of the alternative database where the CTAS temporary table is stored.
         If None, the default `database` is used.

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -113,6 +113,7 @@ Amazon Athena
     create_athena_bucket
     get_query_columns_types
     get_query_execution
+    get_named_query_statement
     get_work_group
     read_sql_query
     read_sql_table

--- a/tutorials/006 - Amazon Athena.ipynb
+++ b/tutorials/006 - Amazon Athena.ipynb
@@ -360,13 +360,6 @@
    "source": [
     "wr.catalog.delete_database('awswrangler_test')"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
### Feature or Bugfix
- Feature

User can obtain the query string with:
```
sql = wr.athena.get_named_query_statement(named_query_id="id")
df = wr.athena.read_sql(sql=sql, database=default)
```

### Relates
- #1177

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
