### PR TITLE
Fix isNull in data api connector

### DIFF
--- a/awswrangler/data_api/connector.py
+++ b/awswrangler/data_api/connector.py
@@ -56,10 +56,10 @@ class DataApiConnector:
         """
         for key in column_value:
             if column_value[key] is not None:
+                if (key == "isNull") and column_value[key]:
+                    return None
                 if key == "arrayValue":
                     raise ValueError(f"arrayValue not supported yet - could not extract {column_value[key]}")
-                elif (key == "isNull") and column_value[key]:
-                    return None
                 return column_value[key]
         return None
 

--- a/awswrangler/data_api/connector.py
+++ b/awswrangler/data_api/connector.py
@@ -58,6 +58,8 @@ class DataApiConnector:
             if column_value[key] is not None:
                 if key == "arrayValue":
                     raise ValueError(f"arrayValue not supported yet - could not extract {column_value[key]}")
+                elif (key == "isNull") and column_value[key]:
+                    return None
                 return column_value[key]
         return None
 

--- a/tests/test_data_api.py
+++ b/tests/test_data_api.py
@@ -89,15 +89,15 @@ def test_data_api_mysql_columnless_query(mysql_serverless_connector):
 
 def test_data_api_mysql_basic_select(mysql_serverless_connector, mysql_serverless_table):
     wr.data_api.rds.read_sql_query(
-        f"CREATE TABLE test.{mysql_serverless_table} (id INT, name VARCHAR(128))", con=mysql_serverless_connector
+        f"CREATE TABLE test.{mysql_serverless_table} (id INT, name VARCHAR(128), missing VARCHAR(256))", con=mysql_serverless_connector
     )
     wr.data_api.rds.read_sql_query(
-        f"INSERT INTO test.{mysql_serverless_table} VALUES (42, 'test')", con=mysql_serverless_connector
+        f"INSERT INTO test.{mysql_serverless_table} (id, name) VALUES (42, 'test')", con=mysql_serverless_connector
     )
     dataframe = wr.data_api.rds.read_sql_query(
         f"SELECT * FROM test.{mysql_serverless_table}", con=mysql_serverless_connector
     )
-    expected_dataframe = pd.DataFrame([[42, "test"]], columns=["id", "name"])
+    expected_dataframe = pd.DataFrame([[42, "test", None]], columns=["id", "name", "missing"])
     pd.testing.assert_frame_equal(dataframe, expected_dataframe)
 
 

--- a/tests/test_data_api.py
+++ b/tests/test_data_api.py
@@ -89,7 +89,8 @@ def test_data_api_mysql_columnless_query(mysql_serverless_connector):
 
 def test_data_api_mysql_basic_select(mysql_serverless_connector, mysql_serverless_table):
     wr.data_api.rds.read_sql_query(
-        f"CREATE TABLE test.{mysql_serverless_table} (id INT, name VARCHAR(128), missing VARCHAR(256))", con=mysql_serverless_connector
+        f"CREATE TABLE test.{mysql_serverless_table} (id INT, name VARCHAR(128), missing VARCHAR(256))",
+        con=mysql_serverless_connector,
     )
     wr.data_api.rds.read_sql_query(
         f"INSERT INTO test.{mysql_serverless_table} (id, name) VALUES (42, 'test')", con=mysql_serverless_connector


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Detail
- Columns with empty values are labeled with `isNull=True` in the [column metadata ](https://github.com/awslabs/aws-data-wrangler/blob/1f42b05e79f634346f4bd48d29be063ad66cc781/awswrangler/data_api/connector.py#L45)response of the Data Api. As result, the column type is erroneously assigned to Boolean instead of None.

### Relates
- #1158

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
