### PR TITLE
Add map type support to redshift copy operation

### DIFF
--- a/awswrangler/_data_types.py
+++ b/awswrangler/_data_types.py
@@ -91,7 +91,7 @@ def pyarrow2redshift(  # pylint: disable=too-many-branches,too-many-return-state
         return f"DECIMAL({dtype.precision},{dtype.scale})"
     if pa.types.is_dictionary(dtype):
         return pyarrow2redshift(dtype=dtype.value_type, string_type=string_type)
-    if pa.types.is_list(dtype) or pa.types.is_struct(dtype):
+    if pa.types.is_list(dtype) or pa.types.is_struct(dtype) or pa.types.is_map(dtype):
         return "SUPER"
     raise exceptions.UnsupportedType(f"Unsupported Redshift type: {dtype}")
 


### PR DESCRIPTION
Subject: Add map type support to redshift copy operation 

### Feature or Bugfix
- Bugfix

### Relates
- [ISSUE-1185](https://github.com/awslabs/aws-data-wrangler/issues/1185)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
