### PR TITLE
Adding workflow for Git Hygiene

### DIFF
--- a/.github/workflows/git-hygiene.yml
+++ b/.github/workflows/git-hygiene.yml
@@ -1,0 +1,44 @@
+
+   
+name: "Close Stale Issues"
+
+on:
+  workflow_dispatch:
+  schedule:
+  - cron: "0 */8 * * *"
+
+jobs:
+  cleanup:
+    permissions:
+      issues: write
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    name: Stale issue job
+    steps:
+    - uses: aws-actions/stale-issue-cleanup@v3
+      with:
+
+        # Messages
+        ancient-issue-message: This issue has not received any attention in 1 year. If you want to keep this issue open, please leave a comment below and auto-close will be canceled.
+        stale-issue-message: This issue has not received a response in a while. If you want to keep this issue open, please leave a comment below and auto-close will be canceled.
+        stale-pr-message: This PR has not received a response in a while. If you want to keep this issue open, please leave a comment below and auto-close will be canceled.
+        
+        # Labels
+        stale-issue-label: closing-soon
+        exempt-issue-label: no-autoclose
+        stale-pr-label: closing-soon
+        exempt-pr-label: no-autoclose
+        response-requested-label: response-requested
+        closed-for-staleness-label: closed-for-staleness
+
+        # Issue timing
+        days-before-stale: 60
+        days-before-close: 7
+        days-before-ancient: 730
+        minimum-upvotes-to-exempt: 5
+
+        # Misc Settings
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        loglevel: DEBUG
+        dry-run: true


### PR DESCRIPTION
Subject: Adding workflow for Git Hygiene

### Feature
- New workflow for managing stale issues and pull requests

### Highlights
- Stale issues (issue with no activity in **60** days) will be scheduled for closure and closed after **7** number of days
- Stale pull requests (PR with no activity in **60** number of days) will be scheduled for closure and closed after **7** number of days
- Ancient issues of older than **730** days will be closed if they do not meet threshold: **5** of upvotes or recent activity.
- Runs periodically every **8** hours.
- Set in `dry-run` mode for now. We can test after merge and change this after validation.
- [Full list of configurable settings](https://github.com/aws-actions/stale-issue-cleanup/blob/main/action.yml#L6)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
