### PR TITLE
Add Python 3.9 support to the build process

### DIFF
--- a/building/build-lambda-layers.sh
+++ b/building/build-lambda-layers.sh
@@ -34,3 +34,11 @@ docker run \
  --rm \
  awswrangler-build-py38 \
  build-lambda-layer.sh "${VERSION}-py3.8" "ninja-build"
+
+# Python 3.9
+docker run \
+ --volume "$DIR_NAME":/aws-data-wrangler/ \
+ --workdir /aws-data-wrangler/building/lambda \
+ --rm \
+ awswrangler-build-py39 \
+ build-lambda-layer.sh "${VERSION}-py3.9" "ninja-build"

--- a/building/lambda/build-docker-images.sh
+++ b/building/lambda/build-docker-images.sh
@@ -28,4 +28,11 @@ docker build \
   --build-arg base_image=public.ecr.aws/lambda/python:3.8 \
   .
 
+# Python 3.9
+docker build \
+  --pull \
+  --tag awswrangler-build-py39 \
+  --build-arg base_image=public.ecr.aws/lambda/python:3.9 \
+  .
+
 rm -rf pyproject.toml poetry.lock


### PR DESCRIPTION
### Feature or Bugfix
- Feature

### Detail
- now that we have a base image with a version available for Python 3.9 we can create an awswrangler layer for it

### Relates
- https://github.com/awslabs/aws-data-wrangler/pull/1162
- By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
