### PR TITLE
bump arrow from 6.0.0 to 6.0.1

### DIFF
--- a/building/lambda/build-lambda-layer.sh
+++ b/building/lambda/build-lambda-layer.sh
@@ -15,7 +15,7 @@ export LD_LIBRARY_PATH=$(pwd)/dist/lib:$LD_LIBRARY_PATH
 
 git clone \
   --depth 1 \
-  --branch apache-arrow-6.0.0 \
+  --branch apache-arrow-6.0.1 \
   --single-branch \
   https://github.com/apache/arrow.git
 


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Detail
- quick PR to use the latest release from Apache Arrow 6.0.x branch

### Relates
- Release notes: https://arrow.apache.org/release/6.0.1.html

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
