### PR TITLE
S3 Proxy support with Data Wrangler

### DIFF
--- a/awswrangler/_utils.py
+++ b/awswrangler/_utils.py
@@ -104,7 +104,10 @@ def _get_endpoint_url(service_name: str) -> Optional[str]:
 
 @apply_configs
 def client(
-    service_name: str, session: Optional[boto3.Session] = None, botocore_config: Optional[botocore.config.Config] = None
+    service_name: str, 
+    session: Optional[boto3.Session] = None, 
+    botocore_config: Optional[botocore.config.Config] = None,
+    verify: Optional[Union[str, bool]] = None,
 ) -> boto3.client:
     """Create a valid boto3.client."""
     endpoint_url: Optional[str] = _get_endpoint_url(service_name=service_name)
@@ -112,13 +115,17 @@ def client(
         service_name=service_name,
         endpoint_url=endpoint_url,
         use_ssl=True,
+        verify=verify,
         config=default_botocore_config() if botocore_config is None else botocore_config,
     )
 
 
 @apply_configs
 def resource(
-    service_name: str, session: Optional[boto3.Session] = None, botocore_config: Optional[botocore.config.Config] = None
+    service_name: str, 
+    session: Optional[boto3.Session] = None, 
+    botocore_config: Optional[botocore.config.Config] = None,
+    verify: Optional[Union[str, bool]] = None,
 ) -> boto3.resource:
     """Create a valid boto3.resource."""
     endpoint_url: Optional[str] = _get_endpoint_url(service_name=service_name)
@@ -126,6 +133,7 @@ def resource(
         service_name=service_name,
         endpoint_url=endpoint_url,
         use_ssl=True,
+        verify=verify,
         config=default_botocore_config() if botocore_config is None else botocore_config,
     )
 

--- a/awswrangler/_utils.py
+++ b/awswrangler/_utils.py
@@ -104,8 +104,8 @@ def _get_endpoint_url(service_name: str) -> Optional[str]:
 
 @apply_configs
 def client(
-    service_name: str, 
-    session: Optional[boto3.Session] = None, 
+    service_name: str,
+    session: Optional[boto3.Session] = None,
     botocore_config: Optional[botocore.config.Config] = None,
     verify: Optional[Union[str, bool]] = None,
 ) -> boto3.client:
@@ -122,8 +122,8 @@ def client(
 
 @apply_configs
 def resource(
-    service_name: str, 
-    session: Optional[boto3.Session] = None, 
+    service_name: str,
+    session: Optional[boto3.Session] = None,
     botocore_config: Optional[botocore.config.Config] = None,
     verify: Optional[Union[str, bool]] = None,
 ) -> boto3.resource:


### PR DESCRIPTION
### Enhancement
-  S3 Proxy support with Data Wrangler


### Detail
- Exposing `verify` argument for boto3 low-level service clients.
  - [boto3.client](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/core/session.html#boto3.session.Session.client)
  - [boto3.resource](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/core/session.html#boto3.session.Session.client)


### Relates
- #1128 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
