### PR TITLE
arm64 support: do not build lambda layers for python3.6/3.7 when arch is arm64

### DIFF
--- a/building/build-lambda-layers.sh
+++ b/building/build-lambda-layers.sh
@@ -4,6 +4,9 @@ set -ex
 VERSION=$(python -c "import awswrangler as wr; print(wr.__version__)")
 DIR_NAME=$(dirname "$PWD")
 
+ARCH=$(arch)
+[ "${ARCH}" = "aarch64" ] && ARCH_SUFFIX="-arm64" # AWS Lambda, the name arm64 is used instead of aarch64
+
 echo "Building Lambda Layers for AWS Data Wrangler ${VERSION}"
 
 pushd lambda
@@ -11,34 +14,36 @@ pushd lambda
 # Building all related docker images
 ./build-docker-images.sh
 
-# Python 3.6
-docker run \
- --volume "$DIR_NAME":/aws-data-wrangler/ \
- --workdir /aws-data-wrangler/building/lambda \
- --rm \
- awswrangler-build-py36 \
- build-lambda-layer.sh "${VERSION}-py3.6" "ninja-build"
+if [ "${ARCH}" != "aarch64" ]; then # https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html
+  # Python 3.6
+  docker run \
+    --volume "$DIR_NAME":/aws-data-wrangler/ \
+    --workdir /aws-data-wrangler/building/lambda \
+    --rm \
+    awswrangler-build-py36 \
+    build-lambda-layer.sh "${VERSION}-py3.6" "ninja-build"
 
-# Python 3.7
-docker run \
- --volume "$DIR_NAME":/aws-data-wrangler/ \
- --workdir /aws-data-wrangler/building/lambda \
- --rm \
- awswrangler-build-py37 \
- build-lambda-layer.sh "${VERSION}-py3.7" "ninja-build"
+  # Python 3.7
+  docker run \
+    --volume "$DIR_NAME":/aws-data-wrangler/ \
+    --workdir /aws-data-wrangler/building/lambda \
+    --rm \
+    awswrangler-build-py37 \
+    build-lambda-layer.sh "${VERSION}-py3.7" "ninja-build"
+fi
 
 # Python 3.8
 docker run \
- --volume "$DIR_NAME":/aws-data-wrangler/ \
- --workdir /aws-data-wrangler/building/lambda \
- --rm \
- awswrangler-build-py38 \
- build-lambda-layer.sh "${VERSION}-py3.8" "ninja-build"
+  --volume "$DIR_NAME":/aws-data-wrangler/ \
+  --workdir /aws-data-wrangler/building/lambda \
+  --rm \
+  awswrangler-build-py38 \
+  build-lambda-layer.sh "${VERSION}-py3.8${ARCH_SUFFIX}" "ninja-build"
 
 # Python 3.9
 docker run \
- --volume "$DIR_NAME":/aws-data-wrangler/ \
- --workdir /aws-data-wrangler/building/lambda \
- --rm \
- awswrangler-build-py39 \
- build-lambda-layer.sh "${VERSION}-py3.9" "ninja-build"
+  --volume "$DIR_NAME":/aws-data-wrangler/ \
+  --workdir /aws-data-wrangler/building/lambda \
+  --rm \
+  awswrangler-build-py39 \
+  build-lambda-layer.sh "${VERSION}-py3.9${ARCH_SUFFIX}" "ninja-build"

--- a/building/lambda/build-docker-images.sh
+++ b/building/lambda/build-docker-images.sh
@@ -6,20 +6,24 @@ cp ../../poetry.lock .
 
 export DOCKER_BUILDKIT=1
 
-# Python 3.6
-docker build \
-  --pull \
-  --tag awswrangler-build-py36 \
-  --build-arg base_image=public.ecr.aws/lambda/python:3.6 \
-  --build-arg python_version=python36 \
-  .
+ARCH=$(arch)
 
-# Python 3.7
-docker build \
-  --pull \
-  --tag awswrangler-build-py37 \
-  --build-arg base_image=public.ecr.aws/lambda/python:3.7 \
-  .
+if [ "${ARCH}" != "aarch64" ]; then
+  # Python 3.6
+  docker build \
+    --pull \
+    --tag awswrangler-build-py36 \
+    --build-arg base_image=public.ecr.aws/lambda/python:3.6 \
+    --build-arg python_version=python36 \
+    .
+
+  # Python 3.7
+  docker build \
+    --pull \
+    --tag awswrangler-build-py37 \
+    --build-arg base_image=public.ecr.aws/lambda/python:3.7 \
+    .
+fi
 
 # Python 3.8
 docker build \


### PR DESCRIPTION
### Feature or Bugfix
- Feature

### Detail
- Lambda's Python3.6 and Python3.7 runtimes are not supported on arm64. Avoid trying to build them when running the build project for Arm64.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
