### PR TITLE
Support additional sql params in Redshift COPY operation

### DIFF
--- a/awswrangler/redshift.py
+++ b/awswrangler/redshift.py
@@ -130,6 +130,7 @@ def _copy(
     boto3_session: Optional[str] = None,
     schema: Optional[str] = None,
     manifest: Optional[bool] = False,
+    sql_copy_extra_params: Optional[List[str]] = [],
 ) -> None:
     if schema is None:
         table_name: str = f'"{table}"'
@@ -147,6 +148,8 @@ def _copy(
     sql: str = f"COPY {table_name}\nFROM '{path}' {auth_str}\nFORMAT AS PARQUET{ser_json_str}"
     if manifest:
         sql += "\nMANIFEST"
+    for param in sql_copy_extra_params:
+        sql += f"\n{param}"
     _logger.debug("copy query:\n%s", sql)
     cursor.execute(sql)
 
@@ -1199,6 +1202,7 @@ def copy_from_files(  # pylint: disable=too-many-locals,too-many-arguments
     lock: bool = False,
     commit_transaction: bool = True,
     manifest: Optional[bool] = False,
+    sql_copy_extra_params: Optional[List[str]] = [],
     boto3_session: Optional[boto3.Session] = None,
     s3_additional_kwargs: Optional[Dict[str, str]] = None,
 ) -> None:
@@ -1361,6 +1365,7 @@ def copy_from_files(  # pylint: disable=too-many-locals,too-many-arguments
                 aws_session_token=aws_session_token,
                 boto3_session=boto3_session,
                 serialize_to_json=serialize_to_json,
+                sql_copy_extra_params=sql_copy_extra_params,
                 manifest=manifest,
             )
             if table != created_table:  # upsert

--- a/awswrangler/redshift.py
+++ b/awswrangler/redshift.py
@@ -130,7 +130,7 @@ def _copy(
     boto3_session: Optional[str] = None,
     schema: Optional[str] = None,
     manifest: Optional[bool] = False,
-    sql_copy_extra_params: Optional[List[str]] = [],
+    sql_copy_extra_params: Optional[List[str]] = None,
 ) -> None:
     if schema is None:
         table_name: str = f'"{table}"'
@@ -148,8 +148,9 @@ def _copy(
     sql: str = f"COPY {table_name}\nFROM '{path}' {auth_str}\nFORMAT AS PARQUET{ser_json_str}"
     if manifest:
         sql += "\nMANIFEST"
-    for param in sql_copy_extra_params:
-        sql += f"\n{param}"
+    if sql_copy_extra_params:
+        for param in sql_copy_extra_params:
+            sql += f"\n{param}"
     _logger.debug("copy query:\n%s", sql)
     cursor.execute(sql)
 
@@ -1202,7 +1203,7 @@ def copy_from_files(  # pylint: disable=too-many-locals,too-many-arguments
     lock: bool = False,
     commit_transaction: bool = True,
     manifest: Optional[bool] = False,
-    sql_copy_extra_params: Optional[List[str]] = [],
+    sql_copy_extra_params: Optional[List[str]] = None,
     boto3_session: Optional[boto3.Session] = None,
     s3_additional_kwargs: Optional[Dict[str, str]] = None,
 ) -> None:


### PR DESCRIPTION
### Feature 
- Support additional sql params in Redshift COPY operation

### Detail
- Adding argument `sql_copy_extra_params` to `awswrangler.redshift.copy_from_files()` to support additional [SQL Params](https://docs.aws.amazon.com/redshift/latest/dg/copy-parameters-data-load.html#copy-statupdate)
- PyTest to evaluate the above.

### Relates
- #1180 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
