### PR TITLE
set encoding to utf-8 when no encoding is specified when reading/writing to s3

### DIFF
--- a/awswrangler/s3/_read_text.py
+++ b/awswrangler/s3/_read_text.py
@@ -28,7 +28,7 @@ def _get_read_details(path: str, pandas_kwargs: Dict[str, Any]) -> Tuple[str, Op
     if pandas_kwargs.get("compression", "infer") == "infer":
         pandas_kwargs["compression"] = infer_compression(path, compression="infer")
     mode: str = "r" if pandas_kwargs.get("compression") is None else "rb"
-    encoding: Optional[str] = pandas_kwargs.get("encoding", None)
+    encoding: Optional[str] = pandas_kwargs.get("encoding", "utf-8")
     newline: Optional[str] = pandas_kwargs.get("lineterminator", None)
     return mode, encoding, newline
 

--- a/awswrangler/s3/_write_text.py
+++ b/awswrangler/s3/_write_text.py
@@ -24,7 +24,7 @@ def _get_write_details(path: str, pandas_kwargs: Dict[str, Any]) -> Tuple[str, O
     if pandas_kwargs.get("compression", "infer") == "infer":
         pandas_kwargs["compression"] = infer_compression(path, compression="infer")
     mode: str = "w" if pandas_kwargs.get("compression") is None else "wb"
-    encoding: Optional[str] = pandas_kwargs.get("encoding", None)
+    encoding: Optional[str] = pandas_kwargs.get("encoding", "utf-8")
     newline: Optional[str] = pandas_kwargs.get("lineterminator", "")
     return mode, encoding, newline
 


### PR DESCRIPTION


### Feature or Bugfix
- Bugfix

### Detail
- set encoding to utf-8 when no encoding is specified when reading/writing to s3
- on Windows, using `athena.read_sql_query` with `ctas_approach=False` and column names containing special characters fails with an `UnicodeDecodeError`. When setting the encoding to utf-8 the error is gone.
- surfacing `pandas_kwargs` (or just an `encoding` argument) all the way up to read_sql_query may not be the best course of action given how utf-8 is widespread nowadays and Athena-own support of other encodings may be lacking and not work as intended. On the other hand, utf-8 can largely be considered the default and this change is unlikely to cause side-effects. I'm happy to discuss this decision though!

### Relates
- #1156

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
