### PR TITLE
add test infrastructure for oracle database

### DIFF
--- a/test_infra/cdk.json
+++ b/test_infra/cdk.json
@@ -11,6 +11,14 @@
     "@aws-cdk/aws-s3:grantWriteWithoutAcl": true,
     "@aws-cdk/aws-ecs-patterns:removeDefaultDesiredCount": true,
     "@aws-cdk/aws-rds:lowercaseDbIdentifier": true,
-    "@aws-cdk/aws-efs:defaultEncryptionAtRest": true
+    "@aws-cdk/aws-efs:defaultEncryptionAtRest": true,
+    "databases": {
+      "redshift": true,
+      "postgresql": true,
+      "mysql": true,
+      "sqlserver": false,
+      "oracle": false,
+      "neptune": false
+    }
   }
 }

--- a/test_infra/stacks/databases_stack.py
+++ b/test_infra/stacks/databases_stack.py
@@ -34,15 +34,23 @@ class DatabasesStack(cdk.Stack):  # type: ignore
         self.key = key
         self.bucket = bucket
 
+        databases_context = self.node.try_get_context("databases")
+
         self._set_db_infra()
         self._set_catalog_encryption()
-        self._setup_redshift()
-        self._setup_postgresql()
-        self._setup_mysql()
-        self._setup_mysql_serverless()
-        self._setup_sqlserver()
-        self._setup_oracle()
-        self._setup_neptune()
+        if databases_context["redshift"]:
+            self._setup_redshift()
+        if databases_context["postgresql"]:
+            self._setup_postgresql()
+        if databases_context["mysql"]:
+            self._setup_mysql()
+            self._setup_mysql_serverless()
+        if databases_context["sqlserver"]:
+            self._setup_sqlserver()
+        if databases_context["oracle"]:
+            self._setup_oracle()
+        if databases_context["neptune"]:
+            self._setup_neptune()
 
     def _set_db_infra(self) -> None:
         self.db_username = "test"


### PR DESCRIPTION
### Feature or Bugfix
- Feature
- Bugfix

### Detail
- add test infrastructure for oracle database
- limit password to 30 characters as 32 characters (default from aws_secretsmanager) is too big for Oracle RDS
- update aurora postgresql from 11.6 to 11.13 as the former is no longer available

### Relates
- #629
- #1259

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
