### PR TITLE
Use DataFrame column names in INSERT statement for UPSERT operation

### DIFF
--- a/awswrangler/redshift.py
+++ b/awswrangler/redshift.py
@@ -174,7 +174,7 @@ def _upsert(
     schema: str,
     primary_keys: Optional[List[str]] = None,
     precombine_key: Optional[str] = None,
-    column_names: List[str] = None
+    column_names: Optional[List[str]] = None
 ) -> None:
     if not primary_keys:
         primary_keys = _get_primary_keys(cursor=cursor, schema=schema, table=table)
@@ -908,11 +908,12 @@ def to_sql(  # pylint: disable=too-many-locals
             )
             if index:
                 df.reset_index(level=df.index.names, inplace=True)
-            column_placeholders: str = ", ".join(["%s"] * len(df.columns))
+            column_names = [c for c in df.columns]
+            column_placeholders: str = ", ".join(["%s"] * len(column_names))
             schema_str = f'"{created_schema}".' if created_schema else ""
             insertion_columns = ""
             if use_column_names:
-                insertion_columns = f"({', '.join(df.columns)})"
+                insertion_columns = f"({', '.join(column_names)})"
             placeholder_parameter_pair_generator = _db_utils.generate_placeholder_parameter_pairs(
                 df=df, column_placeholders=column_placeholders, chunksize=chunksize
             )
@@ -928,7 +929,7 @@ def to_sql(  # pylint: disable=too-many-locals
                     temp_table=created_table,
                     primary_keys=primary_keys,
                     precombine_key=precombine_key,
-                    column_names=df.columns
+                    column_names=column_names
                 )
             if commit_transaction:
                 con.commit()

--- a/awswrangler/redshift.py
+++ b/awswrangler/redshift.py
@@ -174,7 +174,7 @@ def _upsert(
     schema: str,
     primary_keys: Optional[List[str]] = None,
     precombine_key: Optional[str] = None,
-    column_names: Optional[List[str]] = None
+    column_names: Optional[List[str]] = None,
 ) -> None:
     if not primary_keys:
         primary_keys = _get_primary_keys(cursor=cursor, schema=schema, table=table)
@@ -929,7 +929,7 @@ def to_sql(  # pylint: disable=too-many-locals
                     temp_table=created_table,
                     primary_keys=primary_keys,
                     precombine_key=precombine_key,
-                    column_names=column_names
+                    column_names=column_names,
                 )
             if commit_transaction:
                 con.commit()
@@ -1424,7 +1424,7 @@ def copy_from_files(  # pylint: disable=too-many-locals,too-many-arguments
                     table=table,
                     temp_table=created_table,
                     primary_keys=primary_keys,
-                    precombine_key=precombine_key
+                    precombine_key=precombine_key,
                 )
             if commit_transaction:
                 con.commit()

--- a/awswrangler/redshift.py
+++ b/awswrangler/redshift.py
@@ -172,6 +172,7 @@ def _upsert(
     table: str,
     temp_table: str,
     schema: str,
+    column_names: List[str],
     primary_keys: Optional[List[str]] = None,
     precombine_key: Optional[str] = None,
 ) -> None:
@@ -199,7 +200,8 @@ def _upsert(
         sql: str = f'DELETE FROM "{schema}"."{table}" USING {temp_table} WHERE {join_clause}'
         _logger.debug(sql)
         cursor.execute(sql)
-    insert_sql = f"INSERT INTO {schema}.{table} SELECT * FROM {temp_table}"
+    column_names_str = ",".join(column_names)
+    insert_sql = f"INSERT INTO {schema}.{table}({column_names_str}) SELECT {column_names_str} FROM {temp_table}"
     _logger.debug(insert_sql)
     cursor.execute(insert_sql)
     _drop_table(cursor=cursor, schema=schema, table=temp_table)
@@ -923,6 +925,7 @@ def to_sql(  # pylint: disable=too-many-locals
                     temp_table=created_table,
                     primary_keys=primary_keys,
                     precombine_key=precombine_key,
+                    column_names=df.columns
                 )
             if commit_transaction:
                 con.commit()
@@ -1418,6 +1421,7 @@ def copy_from_files(  # pylint: disable=too-many-locals,too-many-arguments
                     temp_table=created_table,
                     primary_keys=primary_keys,
                     precombine_key=precombine_key,
+                    column_names=df.columns
                 )
             if commit_transaction:
                 con.commit()

--- a/awswrangler/redshift.py
+++ b/awswrangler/redshift.py
@@ -908,7 +908,7 @@ def to_sql(  # pylint: disable=too-many-locals
             )
             if index:
                 df.reset_index(level=df.index.names, inplace=True)
-            column_names = [c for c in df.columns]
+            column_names = list(df.columns)
             column_placeholders: str = ", ".join(["%s"] * len(column_names))
             schema_str = f'"{created_schema}".' if created_schema else ""
             insertion_columns = ""


### PR DESCRIPTION
### Feature or Bugfix
<!-- please choose -->
- Feature

### Detail
- Pass DataFrame column names to the _upsert function:
`insert_sql = f"INSERT INTO {schema}.{table}({column_names_str}) SELECT {column_names_str} FROM {temp_table}"`
instead of 
`insert_sql = f"INSERT INTO {schema}.{table} SELECT * FROM {temp_table}"`

### Relates
- [Ticket](https://github.com/awslabs/aws-data-wrangler/issues/1314)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
