### PR TITLE
Modify athena2quicksight datatypes to allow startswith for varchar

### DIFF
--- a/awswrangler/_data_types.py
+++ b/awswrangler/_data_types.py
@@ -345,7 +345,9 @@ def athena2quicksight(dtype: str) -> str:  # pylint: disable=too-many-branches,t
         return "DECIMAL"
     if dtype in ("boolean", "bool"):
         return "BOOLEAN"
-    if dtype in ("string", "char", "varchar"):
+    if dtype.startswith(("char", "varchar")):
+        return "STRING"
+    if dtype == "string":
         return "STRING"
     if dtype == "timestamp":
         return "DATETIME"


### PR DESCRIPTION
### Feature or Bugfix
<!-- please choose -->
- Bugfix

### Detail
- Modify athena2quicksight datatypes to allow startswith for varchar

### Relates
- #1331

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
