### PR TITLE
[skip ci] move opensearch test infra from t3.small to t3.medium

### DIFF
--- a/test_infra/stacks/opensearch_stack.py
+++ b/test_infra/stacks/opensearch_stack.py
@@ -61,7 +61,7 @@ class OpenSearchStack(Stack):  # type: ignore
             domain_name,
             domain_name=domain_name,
             version=opensearch.EngineVersion.OPENSEARCH_1_0,
-            capacity=opensearch.CapacityConfig(data_node_instance_type="t3.small.search", data_nodes=1),
+            capacity=opensearch.CapacityConfig(data_node_instance_type="t3.medium.search", data_nodes=1),
             access_policies=[
                 iam.PolicyStatement(
                     effect=iam.Effect.ALLOW,
@@ -84,7 +84,7 @@ class OpenSearchStack(Stack):  # type: ignore
             domain_name,
             domain_name=domain_name,
             version=opensearch.EngineVersion.ELASTICSEARCH_7_10,
-            capacity=opensearch.CapacityConfig(data_node_instance_type="t3.small.search", data_nodes=1),
+            capacity=opensearch.CapacityConfig(data_node_instance_type="t3.medium.search", data_nodes=1),
             access_policies=[
                 iam.PolicyStatement(
                     effect=iam.Effect.ALLOW,


### PR DESCRIPTION
### Detail
- changing our OpenSearch test instances from t3.small to t3.medium

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
