### PR TITLE
Fix issue with redshift.to_sql() method when mode set to "upsert" and schema contains a hyphen

### DIFF
--- a/awswrangler/redshift.py
+++ b/awswrangler/redshift.py
@@ -202,9 +202,9 @@ def _upsert(
         cursor.execute(sql)
     if column_names:
         column_names_str = ",".join(column_names)
-        insert_sql = f"INSERT INTO {schema}.{table}({column_names_str}) SELECT {column_names_str} FROM {temp_table}"
+        insert_sql = f'INSERT INTO "{schema}"."{table}"({column_names_str}) SELECT {column_names_str} FROM {temp_table}'
     else:
-        insert_sql = f"INSERT INTO {schema}.{table} SELECT * FROM {temp_table}"
+        insert_sql = f'INSERT INTO "{schema}"."{table}" SELECT * FROM {temp_table}'
     _logger.debug(insert_sql)
     cursor.execute(insert_sql)
     _drop_table(cursor=cursor, schema=schema, table=temp_table)


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Detail
-  Unable to use "upsert" mode when using the `wr.redshift.to_sql` method if the schema name contains a hyphen

### Relates
- [Bug: Unable to use a schema with a "-"](https://github.com/awslabs/aws-data-wrangler/issues/1352)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
