### PR TITLE
specify cfn deletion policy for sqlserver and oracle instances

### DIFF
--- a/test_infra/stacks/databases_stack.py
+++ b/test_infra/stacks/databases_stack.py
@@ -522,6 +522,7 @@ class DatabasesStack(Stack):  # type: ignore
         sqlserver = rds.DatabaseInstance(
             self,
             "aws-data-wrangler-sqlserver-instance",
+            removal_policy=RemovalPolicy.DESTROY,
             instance_identifier="sqlserver-instance-wrangler",
             engine=rds.DatabaseInstanceEngine.sql_server_ex(version=rds.SqlServerEngineVersion.VER_15),
             instance_type=ec2.InstanceType.of(ec2.InstanceClass.BURSTABLE3, ec2.InstanceSize.SMALL),
@@ -583,6 +584,7 @@ class DatabasesStack(Stack):  # type: ignore
         oracle = rds.DatabaseInstance(
             self,
             "aws-data-wrangler-oracle-instance",
+            removal_policy=RemovalPolicy.DESTROY,
             instance_identifier="oracle-instance-wrangler",
             engine=rds.DatabaseInstanceEngine.oracle_ee(version=rds.OracleEngineVersion.VER_19_0_0_0_2021_04_R1),
             instance_type=ec2.InstanceType.of(ec2.InstanceClass.BURSTABLE3, ec2.InstanceSize.SMALL),


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Detail
- when deleting our databases stack, final snapshots get in the way for SQL Server and Oracle - they've already been disabled for the other engines

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
