### PR TITLE
fix: Handle column name conflict with reserved sql

### DIFF
--- a/awswrangler/redshift.py
+++ b/awswrangler/redshift.py
@@ -377,7 +377,7 @@ def _create_table(  # pylint: disable=too-many-locals,too-many-arguments,too-man
         sortstyle=sortstyle,
         sortkey=sortkey,
     )
-    cols_str: str = "".join([f"{k} {v},\n" for k, v in redshift_types.items()])[:-2]
+    cols_str: str = "".join([f"\"{k}\" {v},\n" for k, v in redshift_types.items()])[:-2]
     primary_keys_str: str = f",\nPRIMARY KEY ({', '.join(primary_keys)})" if primary_keys else ""
     distkey_str: str = f"\nDISTKEY({distkey})" if distkey and diststyle == "KEY" else ""
     sortkey_str: str = f"\n{sortstyle} SORTKEY({','.join(sortkey)})" if sortkey else ""


### PR DESCRIPTION
The error happened once column name get conflicting with reserved words by redshift. 
Reference here: https://docs.aws.amazon.com/redshift/latest/dg/r_pg_keywords.html

Adding quote to the columns name will help.

### Feature or Bugfix
<!-- please choose -->
- Bugfix

### Detail
The error happened once column name get conflicting with reserved words by redshift,
```
KeyError: ('CREATE TABLE IF NOT EXISTS "app_db"."sys_config" (\nid DECIMAL(20,0),\ngroup VARCHAR(512),....
.....
redshift_connector.error.ProgrammingError: {'S': 'ERROR', 'C': '42601', 'M': 'syntax error at or near "group"', 'P': '84', 'F': '/home/ec2-user/padb/src/pg/src/backend/parser/parser_scan.l', 'L': '714', 'R': 'yyerror'}
```

### Relates
- NA

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
