### PR TITLE
Feature/add use column names to redshift copy

### DIFF
--- a/awswrangler/redshift.py
+++ b/awswrangler/redshift.py
@@ -1587,6 +1587,7 @@ def copy(  # pylint: disable=too-many-arguments,too-many-locals
          If set to True, will use the column names of the DataFrame for generating the INSERT SQL Query.
          E.g. If the DataFrame has two columns `col1` and `col3` and `use_column_names` is True, data will only be
          inserted into the database columns `col1` and `col3`.
+    
     Returns
     -------
     None

--- a/awswrangler/redshift.py
+++ b/awswrangler/redshift.py
@@ -152,7 +152,6 @@ def _copy(
     else:
         sql: str = f"COPY {table_name}\nFROM '{path}' {auth_str}\nFORMAT AS PARQUET{ser_json_str}"
 
-    sql: str = f"COPY {table_name}\nFROM '{path}' {auth_str}\nFORMAT AS PARQUET{ser_json_str}"
     if manifest:
         sql += "\nMANIFEST"
     if sql_copy_extra_params:

--- a/awswrangler/redshift.py
+++ b/awswrangler/redshift.py
@@ -146,12 +146,8 @@ def _copy(
         boto3_session=boto3_session,
     )
     ser_json_str: str = " SERIALIZETOJSON" if serialize_to_json else ""
-    sql: str = ""
-    if column_names:
-        column_names_str = ",".join(column_names)
-        sql = f"COPY {table_name}({column_names_str})\nFROM '{path}' {auth_str}\nFORMAT AS PARQUET{ser_json_str}"
-    else:
-        sql = f"COPY {table_name}\nFROM '{path}' {auth_str}\nFORMAT AS PARQUET{ser_json_str}"
+    column_names_str: str = ",".join(column_names) if column_names else ""
+    sql = f"COPY {table_name}({column_names_str})\nFROM '{path}' {auth_str}\nFORMAT AS PARQUET{ser_json_str}"
 
     if manifest:
         sql += "\nMANIFEST"
@@ -1360,10 +1356,8 @@ def copy_from_files(  # pylint: disable=too-many-locals,too-many-arguments
         When there is a primary_key match during upsert, this column will change the upsert method,
         comparing the values of the specified column from source and target, and keeping the
         larger of the two. Will only work when mode = upsert.
-    column_names: List[str]
-         If not empty, will use the column names of the DataFrame for generating the COPY SQL Query.
-         E.g. If the DataFrame has two columns `col1` and `col3` and `use_column_names` is True, data will only be
-         inserted into the database columns `col1` and `col3`.
+    column_names: List[str], optional
+        List of column names to map source data fields to the target columns.
 
     Returns
     -------
@@ -1584,9 +1578,9 @@ def copy(  # pylint: disable=too-many-arguments,too-many-locals
         comparing the values of the specified column from source and target, and keeping the
         larger of the two. Will only work when mode = upsert.
     use_column_names: bool
-         If set to True, will use the column names of the DataFrame for generating the INSERT SQL Query.
-         E.g. If the DataFrame has two columns `col1` and `col3` and `use_column_names` is True, data will only be
-         inserted into the database columns `col1` and `col3`.
+        If set to True, will use the column names of the DataFrame for generating the INSERT SQL Query.
+        E.g. If the DataFrame has two columns `col1` and `col3` and `use_column_names` is True, data will only be
+        inserted into the database columns `col1` and `col3`.
 
     Returns
     -------
@@ -1611,6 +1605,7 @@ def copy(  # pylint: disable=too-many-arguments,too-many-locals
     """
     path = path[:-1] if path.endswith("*") else path
     path = path if path.endswith("/") else f"{path}/"
+    column_names = [f'"{column}"' for column in df.columns] if use_column_names else []
     session: boto3.Session = _utils.ensure_session(session=boto3_session)
     if s3.list_objects(path=path, boto3_session=session, s3_additional_kwargs=s3_additional_kwargs):
         raise exceptions.InvalidArgument(
@@ -1630,9 +1625,6 @@ def copy(  # pylint: disable=too-many-arguments,too-many-locals
             s3_additional_kwargs=s3_additional_kwargs,
             max_rows_by_file=max_rows_by_file,
         )
-        column_names = []
-        if use_column_names:
-            column_names = [f'"{column}"' for column in df.columns]
         copy_from_files(
             path=path,
             con=con,

--- a/awswrangler/redshift.py
+++ b/awswrangler/redshift.py
@@ -146,8 +146,8 @@ def _copy(
         boto3_session=boto3_session,
     )
     ser_json_str: str = " SERIALIZETOJSON" if serialize_to_json else ""
-    column_names_str: str = ",".join(column_names) if column_names else ""
-    sql = f"COPY {table_name}({column_names_str})\nFROM '{path}' {auth_str}\nFORMAT AS PARQUET{ser_json_str}"
+    column_names_str: str = f"({','.join(column_names)})" if column_names else ""
+    sql = f"COPY {table_name} {column_names_str}\nFROM '{path}' {auth_str}\nFORMAT AS PARQUET{ser_json_str}"
 
     if manifest:
         sql += "\nMANIFEST"

--- a/awswrangler/redshift.py
+++ b/awswrangler/redshift.py
@@ -146,11 +146,12 @@ def _copy(
         boto3_session=boto3_session,
     )
     ser_json_str: str = " SERIALIZETOJSON" if serialize_to_json else ""
+    sql: str = ""
     if column_names:
         column_names_str = ",".join(column_names)
-        sql: str = f"COPY {table_name}({column_names_str})\nFROM '{path}' {auth_str}\nFORMAT AS PARQUET{ser_json_str}"
+        sql = f"COPY {table_name}({column_names_str})\nFROM '{path}' {auth_str}\nFORMAT AS PARQUET{ser_json_str}"
     else:
-        sql: str = f"COPY {table_name}\nFROM '{path}' {auth_str}\nFORMAT AS PARQUET{ser_json_str}"
+        sql = f"COPY {table_name}\nFROM '{path}' {auth_str}\nFORMAT AS PARQUET{ser_json_str}"
 
     if manifest:
         sql += "\nMANIFEST"

--- a/awswrangler/redshift.py
+++ b/awswrangler/redshift.py
@@ -1629,7 +1629,7 @@ def copy(  # pylint: disable=too-many-arguments
             s3_additional_kwargs=s3_additional_kwargs,
             max_rows_by_file=max_rows_by_file,
         )
-        column_names =[]
+        column_names = []
         if use_column_names:
             column_names = [f'"{column}"' for column in df.columns]
         copy_from_files(

--- a/awswrangler/redshift.py
+++ b/awswrangler/redshift.py
@@ -1428,7 +1428,7 @@ def copy_from_files(  # pylint: disable=too-many-locals,too-many-arguments
                 serialize_to_json=serialize_to_json,
                 sql_copy_extra_params=sql_copy_extra_params,
                 manifest=manifest,
-                column_names=column_names
+                column_names=column_names,
             )
             if table != created_table:  # upsert
                 _upsert(
@@ -1438,7 +1438,7 @@ def copy_from_files(  # pylint: disable=too-many-locals,too-many-arguments
                     temp_table=created_table,
                     primary_keys=primary_keys,
                     precombine_key=precombine_key,
-                    column_names=column_names
+                    column_names=column_names,
                 )
             if commit_transaction:
                 con.commit()
@@ -1657,7 +1657,7 @@ def copy(  # pylint: disable=too-many-arguments
             s3_additional_kwargs=s3_additional_kwargs,
             sql_copy_extra_params=sql_copy_extra_params,
             precombine_key=precombine_key,
-            column_names=column_names
+            column_names=column_names,
         )
     finally:
         if keep_files is False:

--- a/awswrangler/redshift.py
+++ b/awswrangler/redshift.py
@@ -1450,7 +1450,7 @@ def copy_from_files(  # pylint: disable=too-many-locals,too-many-arguments
         con.autocommit = autocommit_temp
 
 
-def copy(  # pylint: disable=too-many-arguments
+def copy(  # pylint: disable=too-many-arguments,too-many-locals
     df: pd.DataFrame,
     path: str,
     con: redshift_connector.Connection,

--- a/awswrangler/redshift.py
+++ b/awswrangler/redshift.py
@@ -1587,7 +1587,7 @@ def copy(  # pylint: disable=too-many-arguments,too-many-locals
          If set to True, will use the column names of the DataFrame for generating the INSERT SQL Query.
          E.g. If the DataFrame has two columns `col1` and `col3` and `use_column_names` is True, data will only be
          inserted into the database columns `col1` and `col3`.
-    
+
     Returns
     -------
     None

--- a/tests/test_redshift.py
+++ b/tests/test_redshift.py
@@ -1104,3 +1104,109 @@ def test_to_sql_multi_transaction(redshift_table, redshift_con):
     df3 = wr.redshift.read_sql_query(sql=f"SELECT * FROM public.{redshift_table} ORDER BY id", con=redshift_con)
     assert len(df.index) + len(df2.index) == len(df3.index)
     assert len(df.columns) == len(df3.columns)
+
+def test_copy_with_column_names(redshift_table):
+    con = wr.redshift.connect(connection="aws-data-wrangler-redshift")
+    create_table_sql = (
+        f"CREATE TABLE public.{redshift_table} " "(c0 varchar(100), " "c1 integer default 42, " "c2 integer not null);"
+    )
+    with con.cursor() as cursor:
+        cursor.execute(create_table_sql)
+        con.commit()
+
+    df = pd.DataFrame({"c0": ["foo", "bar"], "c2": [1, 2]})
+
+    with pytest.raises(redshift_connector.error.ProgrammingError):
+        wr.redshift.to_sql(df=df, con=con, schema="public", table=redshift_table, mode="append", use_column_names=False)
+
+    wr.redshift.to_sql(df=df, con=con, schema="public", table=redshift_table, mode="append", use_column_names=True)
+
+    df2 = wr.redshift.read_sql_table(con=con, schema="public", table=redshift_table)
+
+    df["c1"] = 42
+    df["c0"] = df["c0"].astype("string")
+    df["c1"] = df["c1"].astype("Int64")
+    df["c2"] = df["c2"].astype("Int64")
+    df = df.reindex(sorted(df.columns), axis=1)
+    assert df.equals(df2)
+
+def test_copy_upsert_with_column_names(path, redshift_table, redshift_con, databases_parameters):
+    df = pd.DataFrame({"id": list((range(1_000))), "val": list(["foo" if i % 2 == 0 else "boo" for i in range(1_000)])})
+    df3 = pd.DataFrame(
+        {"id": list((range(1_000, 1_500))), "val": list(["foo" if i % 2 == 0 else "boo" for i in range(500)])}
+    )
+
+    # CREATE
+    path = f"{path}upsert/test_redshift_copy_upsert_with_column_names/"
+    wr.redshift.copy(
+        df=df,
+        path=path,
+        con=redshift_con,
+        schema="public",
+        table=redshift_table,
+        mode="overwrite",
+        index=False,
+        primary_keys=["id"],
+        iam_role=databases_parameters["redshift"]["role"],
+        use_column_names=True,
+    )
+    path = f"{path}upsert/test_redshift_copy_upsert_with_column_names2/"
+    df2 = wr.redshift.unload(
+        sql=f"SELECT * FROM public.{redshift_table}",
+        con=redshift_con,
+        iam_role=databases_parameters["redshift"]["role"],
+        path=path,
+        keep_files=False,
+    )
+    assert len(df.index) == len(df2.index)
+    assert len(df.columns) == len(df2.columns)
+
+    # UPSERT
+    path = f"{path}upsert/test_redshift_copy_upsert_with_column_names3/"
+    wr.redshift.copy(
+        df=df3,
+        path=path,
+        con=redshift_con,
+        schema="public",
+        table=redshift_table,
+        mode="upsert",
+        index=False,
+        primary_keys=["id"],
+        iam_role=databases_parameters["redshift"]["role"],
+        use_column_names=True,
+    )
+    path = f"{path}upsert/test_redshift_copy_upsert_with_column_names4/"
+    df4 = wr.redshift.unload(
+        sql=f"SELECT * FROM public.{redshift_table}",
+        con=redshift_con,
+        iam_role=databases_parameters["redshift"]["role"],
+        path=path,
+        keep_files=False,
+    )
+    assert len(df.index) + len(df3.index) == len(df4.index)
+    assert len(df.columns) == len(df4.columns)
+
+    # UPSERT 2 + lock
+    wr.redshift.copy(
+        df=df3,
+        path=path,
+        con=redshift_con,
+        schema="public",
+        table=redshift_table,
+        mode="upsert",
+        index=False,
+        iam_role=databases_parameters["redshift"]["role"],
+        lock=True,
+        use_column_names=True,
+    )
+    path = f"{path}upsert/test_redshift_copy_upsert_with_column_names4/"
+    df4 = wr.redshift.unload(
+        sql=f"SELECT * FROM public.{redshift_table}",
+        con=redshift_con,
+        iam_role=databases_parameters["redshift"]["role"],
+        path=path,
+        keep_files=False,
+    )
+    assert len(df.index) + len(df3.index) == len(df4.index)
+    assert len(df.columns) == len(df4.columns)
+


### PR DESCRIPTION
### Feature or Bugfix
<!-- please choose -->
- Feature

### Detail
- Adding use_column_names to redshift.copy a la redshift.to_sql
- Add copy_upsert_with_column_names test (mimics copy_upsert test)
### Relates

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
