### PR TITLE
Disable Scan selects for parquet files

### DIFF
--- a/awswrangler/s3/_select.py
+++ b/awswrangler/s3/_select.py
@@ -201,6 +201,7 @@ def select_query(
             compression,
             input_serialization_params.get("AllowQuotedRecordDelimiter"),
             input_serialization_params.get("Type") == "Document",
+            input_serialization == "Parquet",
         ]
     ):  # Scan range is only supported for uncompressed CSV/JSON, CSV (without quoted delimiters)
         # and JSON objects (in LINES mode only)


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Detail
- S3 SELECT queries with a Scan range don't really make sense for parquet files, that's why we should fall back to the "defazlt" query in this case as well

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
