### PR TITLE
Prevent creation attempt for the default bucket if bucket already exists

### DIFF
--- a/awswrangler/athena/_utils.py
+++ b/awswrangler/athena/_utils.py
@@ -364,6 +364,9 @@ def create_athena_bucket(boto3_session: Optional[boto3.Session] = None) -> str:
     path = f"s3://{bucket_name}/"
     resource = _utils.resource(service_name="s3", session=session)
     bucket = resource.Bucket(bucket_name)
+    if bucket.creation_date is not None:
+        # Bucket already exists, just return the path
+        return path
     args = {} if region_name == "us-east-1" else {"CreateBucketConfiguration": {"LocationConstraint": region_name}}
     try:
         bucket.create(**args)


### PR DESCRIPTION
### Feature or Bugfix
<!-- please choose -->
- Bugfix

### Detail
- check to see if the Athena results output bucket exists before creating it.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
