### PR TITLE
ci: add GitHub token permissions for workflows

### DIFF
--- a/.github/workflows/bandit.yml
+++ b/.github/workflows/bandit.yml
@@ -9,6 +9,9 @@ on:
     branches:
     - main
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/cfn-nag.yml
+++ b/.github/workflows/cfn-nag.yml
@@ -13,6 +13,9 @@ on:
     branches:
     - main
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/minimal-tests.yml
+++ b/.github/workflows/minimal-tests.yml
@@ -8,6 +8,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   Check:
 

--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -3,6 +3,9 @@ name: Snyk
 on:
   workflow_dispatch
 
+permissions:
+  contents: read
+
 jobs:
   security:
     runs-on: ubuntu-latest

--- a/.github/workflows/static-checking.yml
+++ b/.github/workflows/static-checking.yml
@@ -8,6 +8,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   Check:
 

--- a/.github/workflows/unlabel-assigned-issue.yml
+++ b/.github/workflows/unlabel-assigned-issue.yml
@@ -3,8 +3,14 @@ on:
   issues:
     types:
       - assigned
+permissions:
+  contents: read
+
 jobs:
   unlabel-issue:
+    permissions:
+      issues: write  # for andymckay/labeler to label issues
+      pull-requests: write  # for andymckay/labeler to label PRs
     runs-on: ubuntu-latest
     steps:
       - name: unlabel-issues


### PR DESCRIPTION
### Feature or Bugfix
<!-- please choose -->
- Security best practice

### Detail

This PR adds minimum token permissions for the GITHUB_TOKEN using https://github.com/step-security/secure-workflows.

GitHub recommends defining minimum GITHUB_TOKEN permissions for securing GitHub Actions workflows 
- https://github.blog/changelog/2021-04-20-github-actions-control-permissions-for-github_token/  
- https://docs.github.com/en/actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token
- The Open Source Security Foundation (OpenSSF) [Scorecards](https://github.com/ossf/scorecard) treats not setting token permissions as a high-risk issue. Merging this PR will also help improve the Scorecard score for this project.  

Signed-off-by: Varun Sharma <varunsh@stepsecurity.io>

### Before this change
`GITHUB_TOKEN` has `write` permissions for multiple scopes which are not needed. 
e.g. https://github.com/awslabs/aws-data-wrangler/runs/7628091514?check_suite_focus=true#step:1:19

### After this change
`GITHUB_TOKEN` will have minimum permissions needed. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
