### PR TITLE
Updating CONTRIBUTING.md and CONTRIBUTING_COMMON_ERRORS.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -246,11 +246,11 @@ or
 
 * To run a specific test function:
 
-``pytest tests/test_db.py::test_sql``
+``pytest tests/test_mysql.py::test_read_sql_query_simple``
 
-* To run all database test functions (Using 8 parallel processes):
+* To run all database test functions for MySQL (Using 8 parallel processes):
 
-``pytest -n 8 tests/test_db.py``
+``pytest -n 8 tests/test_mysql.py``
 
 * To run all data lake test functions for all python versions (Only if Amazon QuickSight is activated and Amazon OpenSearch template is deployed):
 

--- a/CONTRIBUTING_COMMON_ERRORS.md
+++ b/CONTRIBUTING_COMMON_ERRORS.md
@@ -111,3 +111,22 @@ brew install unixodbc
 ```
 
 -----
+
+## CloudFormation Deployment
+
+### Error Message
+
+During the deployment of `aws-data-wrangler-databases`, the creation of the resource `CodeBuildTestRoleLFPermissions` fails with
+
+```
+Resource does not exist or requester is not authorized to access requested permissions. (Service: AWSLakeFormation; Status Code: 400; Error Code: AccessDeniedException; Request ID: 14a26718-ee4e-49f2-a7ca-d308e49485f8; Proxy: null)
+```
+
+### Solution
+
+The IAM role used to deploy the CloudForation stack does not have permissions to assign permissions in AWS Lake Formation. The quickest solution is to find the IAM role and set it as an admin in Lake Formation.
+
+In order to find the role:
+1. Navigate to the CloudFormation console in your account
+1. Select the `aws-data-wrangler-databases` stack which failed to deploy
+1. Under the "Stack info" tab, find the value for "IAM role". The name of the role should be in the following format: `arn:aws:iam::{ACCOUNT_ID}:role/cdk-{UUID}-cfn-exec-role-{ACCOUNT_ID}-{REGION}`


### PR DESCRIPTION
### Description of changes
1. An entry was added to [CONTRIBUTING_COMMON_ERRORS](https://github.com/awslabs/aws-data-wrangler/blob/main/CONTRIBUTING_COMMON_ERRORS.md) page which specifies that the IAM role used by CloudFormation needs to be added as a Lake Formation admin.
1. Fix instructions for how to run a unit test for the databases. This guide was previously referencing a non-existent test file.

### Relates
https://github.com/awslabs/aws-data-wrangler/issues/1497

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
