### PR TITLE
Check for pair of brackets in query preparation for Athena cache

### DIFF
--- a/awswrangler/athena/_cache.py
+++ b/awswrangler/athena/_cache.py
@@ -116,7 +116,9 @@ def _prepare_query_string_for_comparison(query_string: str) -> str:
     """To use cached data, we need to compare queries. Returns a query string in canonical form."""
     # for now this is a simple complete strip, but it could grow into much more sophisticated
     # query comparison data structures
-    query_string = "".join(query_string.split()).strip("()").lower()
+    query_string = "".join(query_string.split()).strip().lower()
+    while query_string.startswith("(") and query_string.endswith(")"):
+        query_string = query_string[1:-1]
     query_string = query_string[:-1] if query_string.endswith(";") else query_string
     return query_string
 


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix


### Detail
When preparing queries for comparisons, brackets are just stripped from the query string which in some cases leads to deeming queries unequal even if they are the same.

One example would be a query like:
```sql
SELECT *
FROM my_tbl
ORDER BY (col_1, col_2);
```

If i run this query twice against Athena it will think these are two different queries as it will just remove the `)` in the end.

To prevent cases like this, my proposal would be to just check for columns which encapsulate the complete query. I know that also this is not perfect, but at least is a little bit better that it is right now. However, this is debatable and I'm open for a discussion :slightly_smiling_face: 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
