### PR TITLE
fix: add AWS_REGION by default to deltalake storage_options

### DIFF
--- a/awswrangler/s3/_read_deltalake.py
+++ b/awswrangler/s3/_read_deltalake.py
@@ -22,6 +22,7 @@ def _set_default_storage_options_kwargs(
     boto3_session: Optional[boto3.Session], s3_additional_kwargs: Optional[Dict[str, Any]]
 ) -> Dict[str, Any]:
     defaults = {key.upper(): value for key, value in _utils.boto3_to_primitives(boto3_session=boto3_session).items()}
+    defaults["AWS_REGION"] = defaults.pop("REGION_NAME")
     s3_additional_kwargs = s3_additional_kwargs or {}
     return {
         **defaults,

--- a/awswrangler/s3/_write_deltalake.py
+++ b/awswrangler/s3/_write_deltalake.py
@@ -23,6 +23,7 @@ def _set_default_storage_options_kwargs(
     boto3_session: Optional[boto3.Session], s3_additional_kwargs: Optional[Dict[str, Any]], s3_allow_unsafe_rename: bool
 ) -> Dict[str, Any]:
     defaults = {key.upper(): value for key, value in _utils.boto3_to_primitives(boto3_session=boto3_session).items()}
+    defaults["AWS_REGION"] = defaults.pop("REGION_NAME")
     s3_additional_kwargs = s3_additional_kwargs or {}
     return {
         **defaults,


### PR DESCRIPTION
### Feature or Bugfix
<!-- please choose -->
- BugFix

In deltalake, [storage_options](https://docs.rs/object_store/latest/object_store/aws/enum.AmazonS3ConfigKey.html#variants) expects a `AWS_REGION` or `REGION` key when we have been passing `REGION_NAME` which is not supported

### Detail
- Pass `AWS_REGION` instead of `REGION_NAME`

### Relates
- #2308

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
