### PR TITLE
chore: replace deprecated pr linting action

### DIFF
--- a/.github/workflows/pr-linter.yml
+++ b/.github/workflows/pr-linter.yml
@@ -10,10 +10,11 @@ on:
 
 jobs:
   lint:
+    name: Validate PR title
     runs-on: ubuntu-latest
     permissions:
-      statuses: write
+      pull-requests: read
     steps:
-      - uses: aslafy-z/conventional-pr-title-action@v3
+      - uses: amannn/action-semantic-pull-request@v6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### Feature or Bugfix
- Feature

### Detail
- https://github.com/aslafy-z/conventional-pr-title-action was deprecated in favour of https://github.com/amannn/action-semantic-pull-request

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
