### PR TITLE
chore: Update Snyk action

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - name: Run Snyk to check for vulnerabilities
-        uses: snyk/actions/python-3.8@master
+        uses: snyk/actions/python-3.12@master
         continue-on-error: true  # To make sure that SARIF upload gets called
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}


### PR DESCRIPTION
### Detail
```
Run echo "::warning title=Deprecated Action::The action python-3.8 is deprecated. Please visit Snyk actions at https://github.com/snyk/actions for a newer version."
  echo "::warning title=Deprecated Action::The action python-3.8 is deprecated. Please visit Snyk actions at https://github.com/snyk/actions for a newer version."
  shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
  env:
    SNYK_TOKEN: ***

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
